### PR TITLE
Added the vLLM CPU supported for ChatQnA Application

### DIFF
--- a/ChatQnA/README.md
+++ b/ChatQnA/README.md
@@ -8,15 +8,288 @@ ChatQnA architecture shows below:
 
 ![architecture](https://i.imgur.com/lLOnQio.png)
 
-This ChatQnA use case performs RAG using LangChain, Redis vectordb and Text Generation Inference on Intel Gaudi2 or Intel XEON Scalable Processors. The Intel Gaudi2 accelerator supports both training and inference for deep learning models in particular for LLMs. Please visit [Habana AI products](https://habana.ai/products) for more details.
+This ChatQnA use case performs RAG using LangChain, Redis vectordb, Text Generation Inference and vLLM on Intel Gaudi2 or Intel XEON Scalable Processors. The Intel XEON Scalable Processors and Gaudi2 accelerator support both training and inference for deep learning models in particular for LLMs. Please visit [Intel products](https://www.intel.com/content/www/us/en/products/overview.html) and [Habana AI products](https://habana.ai/products) for more details.
 
-# Deploy ChatQnA Service
+# Solution Overview
 
-The ChatQnA service can be effortlessly deployed on either Intel Gaudi2 or Intel XEON Scalable Processors.
+Steps to implement the solution are as follows
 
-## Deploy ChatQnA on Gaudi
+## In Intel Gaudi2 Platform
 
-Refer to the [Gaudi Guide](./microservice/gaudi/README.md) for instructions on deploying ChatQnA on Gaudi.
+1. [Deploy a TGI container with LLM model of your choice](#launch-tgi-gaudi-service) (Solution uses 70B model by default)
+
+## In Intel Xeon Platform
+
+**Using TGI Endpoint Service**
+
+1. [Export TGI endpoint as environment variable](#customize-tgi-gaudi-service)
+
+or **Using vLLM Endpoint Service**
+
+1. [Export vLLM endpoint as environment variable](#customize-vllm-cpu-service)
+
+2. [Deploy a TEI container for Embedding model service and export the endpoint](#enable-tei-for-embedding-model)
+3. [Launch a Redis container and Langchain container](#launch-redis-and-langchain-backend-service)
+4. [Ingest data into redis](#ingest-data-into-redis), this example provides few example PDF documents
+5. [Start the backend service](#start-the-backend-service) to accept queries to Langchain
+6. [Start the GUI](#start-the-frontend-service) based chatbot service to experiment with RAG based Chatbot
+
+To use [🤗 text-generation-inference](https://github.com/huggingface/text-generation-inference) on Habana Gaudi/Gaudi2, please follow these steps:
+
+## Prepare LLM Endpoint Service
+
+### Prepare TGI Docker
+
+Getting started is straightforward with the official Docker container. Simply pull the image using:
+
+```bash
+docker pull ghcr.io/huggingface/tgi-gaudi:1.2.1
+```
+
+Alternatively, you can build the Docker image yourself using latest [TGI-Gaudi](https://github.com/huggingface/tgi-gaudi) code with the below command:
+
+```bash
+bash ./serving/tgi_gaudi/build_docker.sh
+```
+
+### Launch TGI Gaudi Service
+
+#### Launch a local server instance on 1 Gaudi card:
+
+```bash
+bash ./serving/tgi_gaudi/launch_tgi_service.sh
+```
+
+For gated models such as `LLAMA-2`, you will have to pass -e HUGGING_FACE_HUB_TOKEN=\<token\> to the docker run command above with a valid Hugging Face Hub read token.
+
+Please follow this link [huggingface token](https://huggingface.co/docs/hub/security-tokens) to get the access token and export `HUGGINGFACEHUB_API_TOKEN` environment with the token.
+
+```bash
+export HUGGINGFACEHUB_API_TOKEN=<token>
+```
+
+#### Launch a local server instance on 8 Gaudi cards:
+
+```bash
+bash ./serving/tgi_gaudi/launch_tgi_service.sh 8
+```
+
+And then you can make requests like below to check the service status:
+
+```bash
+curl 127.0.0.1:8080/generate \
+  -X POST \
+  -d '{"inputs":"What is Deep Learning?","parameters":{"max_new_tokens":32}}' \
+  -H 'Content-Type: application/json'
+```
+
+#### Customize TGI Gaudi Service
+
+The ./serving/tgi_gaudi/launch_tgi_service.sh script accepts three parameters:
+
+- num_cards: The number of Gaudi cards to be utilized, ranging from 1 to 8. The default is set to 1.
+- port_number: The port number assigned to the TGI Gaudi endpoint, with the default being 8080.
+- model_name: The model name utilized for LLM, with the default set to "Intel/neural-chat-7b-v3-3".
+
+You have the flexibility to customize these parameters according to your specific needs. Additionally, you can set the TGI Gaudi endpoint by exporting the environment variable `TGI_LLM_ENDPOINT`:
+
+```bash
+export TGI_LLM_ENDPOINT="http://xxx.xxx.xxx.xxx:8080"
+```
+
+### Prepare vLLM Docker
+
+Getting started is straightforward with the official Docker container. You can build the Docker image yourself using latest [vLLM-CPU](https://github.com/vllm-project/vllm) code with the below command:
+
+```bash
+bash ./serving/vllm/build_docker_cpu.sh
+```
+
+### Launch vLLM CPU Service
+
+#### Launch a local server instance:
+
+```bash
+bash ./serving/vllm/launch_vllm_service.sh
+```
+
+For gated models such as `LLAMA-2`, you will have to pass -e HUGGING_FACE_HUB_TOKEN=\<token\> to the docker run command above with a valid Hugging Face Hub read token.
+
+Please follow this link [huggingface token](https://huggingface.co/docs/hub/security-tokens) to get the access token and export `HUGGINGFACEHUB_API_TOKEN` environment with the token.
+
+```bash
+export HUGGINGFACEHUB_API_TOKEN=<token>
+```
+
+And then you can make requests like below to check the service status:
+
+```bash
+curl http://127.0.0.1::8080/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+  "model": <model_name>,
+  "prompt": "What is Deep Learning?",
+  "max_tokens": 32,
+  "temperature": 0
+  }'
+```
+
+#### Customize vLLM CPU Service
+
+The ./serving/vllm/launch_vllm_service.sh script accepts two parameters:
+
+- port_number: The port number assigned to the vLLM CPU endpoint, with the default being 8080.
+- model_name: The model name utilized for LLM, with the default set to "mistralai/Mistral-7B-v0.1".
+
+You have the flexibility to customize twp parameters according to your specific needs. Additionally, you can set the vLLM CPU endpoint by exporting the environment variable `vLLM_LLM_ENDPOINT`:
+
+```bash
+export vLLM_LLM_ENDPOINT="http://xxx.xxx.xxx.xxx:8080"
+export LLM_MODEL=<model_name> # example: export LLM_MODEL="mistralai/Mistral-7B-v0.1"
+```
+
+## Enable TEI for embedding model
+
+Text Embeddings Inference (TEI) is a toolkit designed for deploying and serving open-source text embeddings and sequence classification models efficiently. With TEI, users can extract high-performance features using various popular models. It supports token-based dynamic batching for enhanced performance.
+
+To launch the TEI service, you can use the following commands:
+
+```bash
+model=BAAI/bge-large-en-v1.5
+revision=refs/pr/5
+volume=$PWD/data # share a volume with the Docker container to avoid downloading weights every run
+docker run -p 9090:80 -v $volume:/data -e http_proxy=$http_proxy -e https_proxy=$https_proxy --pull always ghcr.io/huggingface/text-embeddings-inference:cpu-1.2 --model-id $model --revision $revision
+export TEI_ENDPOINT="http://xxx.xxx.xxx.xxx:9090"
+```
+
+And then you can make requests like below to check the service status:
+
+```bash
+curl 127.0.0.1:9090/embed \
+    -X POST \
+    -d '{"inputs":"What is Deep Learning?"}' \
+    -H 'Content-Type: application/json'
+```
+
+Note: If you want to integrate the TEI service into the LangChain application, you'll need to restart the LangChain backend service after launching the TEI service.
+
+## Launch Redis and LangChain Backend Service
+
+Update the `HUGGINGFACEHUB_API_TOKEN` environment variable with your huggingface token in the `docker-compose.yml`
+
+```bash
+cd langchain/docker
+docker compose -f docker-compose.yml up -d
+cd ../../
+```
+
+> [!NOTE]
+> If you modified any files and want that change introduced in this step, add `--build` to the end of the command to build the container image instead of pulling it from dockerhub.
+
+## Ingest data into Redis
+
+Each time the Redis container is launched, data should be ingested into the container using the commands:
+
+```bash
+docker exec -it qna-rag-redis-server bash
+cd /ws
+python ingest.py
+```
+
+Note: `ingest.py` will download the embedding model. Please set the proxy if necessary.
+
+# Start LangChain Server
+
+## Enable GuardRails using Meta's Llama Guard model (Optional)
+
+We offer content moderation support utilizing Meta's [Llama Guard](https://huggingface.co/meta-llama/LlamaGuard-7b) model. To activate GuardRails, kindly follow the instructions below to deploy the Llama Guard model on TGI Gaudi.
+
+```bash
+volume=$PWD/data
+model_id="meta-llama/LlamaGuard-7b"
+docker run -p 8088:80 -v $volume:/data --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --ipc=host -e HUGGING_FACE_HUB_TOKEN=<your HuggingFace token> -e HTTPS_PROXY=$https_proxy -e HTTP_PROXY=$https_proxy tgi_gaudi --model-id $model_id
+export SAFETY_GUARD_ENDPOINT="http://xxx.xxx.xxx.xxx:8088"
+```
+
+And then you can make requests like below to check the service status:
+
+```bash
+curl 127.0.0.1:8088/generate \
+  -X POST \
+  -d '{"inputs":"How do you buy a tiger in the US?","parameters":{"max_new_tokens":32}}' \
+  -H 'Content-Type: application/json'
+```
+
+## Start the Backend Service
+
+Make sure TGI-Gaudi service is running and also make sure data is populated into Redis. Launch the backend service:
+
+```bash
+docker exec -it qna-rag-redis-server bash
+# export TGI_LLM_ENDPOINT="http://xxx.xxx.xxx.xxx:8080" - can be omitted if set before in docker-compose.yml
+# export TEI_ENDPOINT="http://xxx.xxx.xxx.xxx:9090" - Needs to be added only if TEI to be used and can be omitted if set before in docker-compose.yml
+nohup python app/server.py &
+```
+
+The LangChain backend service listens to port 8000, you can customize it by changing the code in `docker/qna-app/app/server.py`.
+
+And then you can make requests like below to check the LangChain backend service status:
+
+```bash
+# non-streaming endpoint
+curl 127.0.0.1:8000/v1/rag/chat \
+  -X POST \
+  -d '{"query":"What is the total revenue of Nike in 2023?"}' \
+  -H 'Content-Type: application/json'
+```
+
+```bash
+# streaming endpoint
+curl 127.0.0.1:8000/v1/rag/chat_stream \
+  -X POST \
+  -d '{"query":"What is the total revenue of Nike in 2023?"}' \
+  -H 'Content-Type: application/json'
+```
+
+## Start the Frontend Service
+
+Navigate to the "ui" folder and execute the following commands to start the frontend GUI:
+
+```bash
+cd ui
+sudo apt-get install npm && \
+    npm install -g n && \
+    n stable && \
+    hash -r && \
+    npm install -g npm@latest
+```
+
+For CentOS, please use the following commands instead:
+
+```bash
+curl -sL https://rpm.nodesource.com/setup_20.x | sudo bash -
+sudo yum install -y nodejs
+```
+
+Update the `DOC_BASE_URL` environment variable in the `.env` file by replacing the IP address '127.0.0.1' with the actual IP address.
+
+Run the following command to install the required dependencies:
+
+```bash
+npm install
+```
+
+Start the development server by executing the following command:
+
+```bash
+nohup npm run dev &
+```
+
+This will initiate the frontend service and launch the application.
+
+# Enable TGI Gaudi FP8 for higher throughput (Optional)
+
+The TGI Gaudi utilizes BFLOAT16 optimization as the default setting. If you aim to achieve higher throughput, you can enable FP8 quantization on the TGI Gaudi. Note that currently only Llama2 series and Mistral series models support FP8 quantization. Please follow the below steps to enable FP8 quantization.
 
 ## Deploy ChatQnA on Xeon
 

--- a/ChatQnA/serving/vllm/build_docker_cpu.sh
+++ b/ChatQnA/serving/vllm/build_docker_cpu.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+git clone https://github.com/vllm-project/vllm.git
+cd ./vllm/
+docker build -f Dockerfile.cpu -t vllm-cpu-env --shm-size=128g . --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy

--- a/ChatQnA/serving/vllm/launch_vllm_service.sh
+++ b/ChatQnA/serving/vllm/launch_vllm_service.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set default values
+default_port=8080
+default_model="mistralai/Mistral-7B-v0.1"
+
+# Assign arguments to variables
+port_number=${1:-$default_port}
+model_name=${2:-$default_model}
+
+# Check if all required arguments are provided
+if [ "$#" -lt 0 ] || [ "$#" -gt 2 ]; then
+    echo "Usage: $0 [port_number] [model_name]"
+    exit 1
+fi
+
+# Set the volume variable
+volume=$PWD/data
+
+# Build the Docker run command based on the number of cards
+docker run -it --rm --name="ChatQnA_server" -p $port_number:$port_number --network=host -v $volume:/data -e HTTPS_PROXY=$https_proxy -e HTTP_PROXY=$https_proxy vllm-cpu-env /bin/bash -c "cd / && export VLLM_CPU_KVCACHE_SPACE=40 && python3 -m vllm.entrypoints.openai.api_server --model $model_name --port $port_number"


### PR DESCRIPTION
## Type of Change

Added the vLLM CPU service for an alternative model serving method in the ChatQnA application.

## Description

This PR is adding the vLLM serving on the CPU as the LLM backend service in the ChatQnA application. As the vLLM only supports the CPU now, so we will add the vLLM CPU serving solution first. vLLM serving on the Gaudi will be added while its ready.

## How has this PR been tested?

This PR is tested in the Gaudi2 server with:
-  2 sockers Intel(R) Xeon(R) Platinum 8368 CPU @ 2.40GHz 
-  8 Gaudi nodes, HL-SMI Version:  hl-1.14.0-fw-48.0.1.0 Driver Version: 1.14.0-9e8ecf8

which is tested well in the above env:
- **vllm engine backend**
![image](https://github.com/opea-project/GenAIExamples/assets/87695601/7ab10313-f8d8-4b28-a7c4-9a5772393a26)
- **rag supported**
![image](https://github.com/opea-project/GenAIExamples/assets/87695601/644b3c02-5e0c-4317-a590-b520ffab52ef)
- **user query post successfully via vllm and rag support**
![image](https://github.com/opea-project/GenAIExamples/assets/87695601/54794b1f-b66c-4f0f-9bc5-15124fa4c828)



## Dependency Change?
vLLM and openai libs will be introduced into the ChatQnA application.
Th vLLM CPU support issues have been resolved and merged in the vllm through this [PR](https://github.com/vllm-project/vllm/pull/3993#issuecomment-2058346756).
