### PR TITLE
Enable WikiQnA to empower enterprise to use  internal wiki resources for RAG.

### DIFF
--- a/ChatQnA/langchain/docker/docker-compose.yml
+++ b/ChatQnA/langchain/docker/docker-compose.yml
@@ -30,7 +30,16 @@ services:
     container_name: qna-rag-redis-server
     environment:
       - https_proxy=${https_proxy}
+      - http_proxy=${http_proxy}
+      - HTTP_PROXY=${HTTP_PROXY}
+      - HTTPS_PROXY=${HTTPS_PROXY}
+      - no_proxy=${no_proxy}
+      - SOCKS_PROXY=${SOCKS_PROXY}
+      - socks_proxy=${socks_proxy}
+      - FTP_PROXY=${FTP_PROXY}
+      - ftp_proxy=${ftp_proxy}
       - HUGGINGFACEHUB_API_TOKEN=${HUGGINGFACEHUB_API_TOKEN}
+      - CONFLUENCE_ACCESS_TOKEN=${CONFLUENCE_ACCESS_TOKEN}
       - "REDIS_PORT=6379"
       - "EMBED_MODEL=BAAI/bge-base-en-v1.5"
       - "REDIS_SCHEMA=schema_dim_768.yml"

--- a/ChatQnA/langchain/docker/requirements.txt
+++ b/ChatQnA/langchain/docker/requirements.txt
@@ -7,6 +7,7 @@ jupyter
 langchain==0.1.12
 langchain-cli
 langchain_benchmarks
+atlassian-python-api
 poetry
 pyarrow
 pydantic==1.10.13

--- a/ChatQnA/langchain/docker/requirements.txt
+++ b/ChatQnA/langchain/docker/requirements.txt
@@ -1,4 +1,5 @@
 -f https://download.pytorch.org/whl/torch_stable.html
+atlassian-python-api
 cryptography==42.0.4
 easyocr
 intel-extension-for-pytorch
@@ -7,7 +8,6 @@ jupyter
 langchain==0.1.12
 langchain-cli
 langchain_benchmarks
-atlassian-python-api
 poetry
 pyarrow
 pydantic==1.10.13

--- a/ChatQnA/langchain/redis/ingest_wiki.py
+++ b/ChatQnA/langchain/redis/ingest_wiki.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+
+import numpy as np
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceEmbeddings, HuggingFaceHubEmbeddings
+from langchain_community.vectorstores import Redis
+from PIL import Image
+from rag_redis.config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
+
+tei_embedding_endpoint = os.getenv("TEI_ENDPOINT")
+
+
+def pdf_loader(file_path):
+    try:
+        import easyocr
+        import fitz
+    except ImportError:
+        raise ImportError(
+            "`PyMuPDF` or 'easyocr' package is not found, please install it with "
+            "`pip install pymupdf or pip install easyocr.`"
+        )
+
+    doc = fitz.open(file_path)
+    reader = easyocr.Reader(["en"])
+    result = ""
+    for i in range(doc.page_count):
+        page = doc.load_page(i)
+        pagetext = page.get_text().strip()
+        if pagetext:
+            result = result + pagetext
+        if len(doc.get_page_images(i)) > 0:
+            for img in doc.get_page_images(i):
+                if img:
+                    pageimg = ""
+                    xref = img[0]
+                    img_data = doc.extract_image(xref)
+                    img_bytes = img_data["image"]
+                    pil_image = Image.open(io.BytesIO(img_bytes))
+                    img = np.array(pil_image)
+                    img_result = reader.readtext(img, paragraph=True, detail=0)
+                    pageimg = pageimg + ", ".join(img_result).strip()
+                    if pageimg.endswith("!") or pageimg.endswith("?") or pageimg.endswith("."):
+                        pass
+                    else:
+                        pageimg = pageimg + "."
+                result = result + pageimg
+    return result
+
+
+def ingest_documents():
+    """Ingest PDF to Redis from the data/ directory that
+    contains Intel manuals."""
+    # Load list of pdfs
+    company_name = "Intel"
+    data_path = "data_intel/"
+    doc_path = [os.path.join(data_path, file) for file in os.listdir(data_path)][0]
+
+    print("Parsing Intel architecture manuals", doc_path)
+
+    text_splitter = RecursiveCharacterTextSplitter(chunk_size=1500, chunk_overlap=100, add_start_index=True)
+    content = pdf_loader(doc_path)
+    chunks = text_splitter.split_text(content)
+
+    print("Done preprocessing. Created", len(chunks), "chunks of the original pdf")
+    # Create vectorstore
+    # Create vectorstore
+    if tei_embedding_endpoint:
+        # create embeddings using TEI endpoint service
+        embedder = HuggingFaceHubEmbeddings(model=tei_embedding_endpoint)
+    else:
+        # create embeddings using local embedding model
+        embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+
+    # Batch size
+    batch_size = 32
+    num_chunks = len(chunks)
+    for i in range(0, num_chunks, batch_size):
+        batch_chunks = chunks[i : i + batch_size]
+        batch_texts = [f"Company: {company_name}. " + chunk for chunk in batch_chunks]
+
+        _ = Redis.from_texts(
+            texts=batch_texts,
+            embedding=embedder,
+            index_name=INDEX_NAME,
+            index_schema=INDEX_SCHEMA,
+            redis_url=REDIS_URL,
+        )
+        print(f"Processed batch {i//batch_size + 1}/{(num_chunks-1)//batch_size + 1}")
+
+
+if __name__ == "__main__":
+    ingest_documents()

--- a/ChatQnA/langchain/redis/ingest_wiki.py
+++ b/ChatQnA/langchain/redis/ingest_wiki.py
@@ -20,33 +20,40 @@ import os
 
 import numpy as np
 from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.document_loaders import ConfluenceLoader
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceEmbeddings, HuggingFaceHubEmbeddings
 from langchain_community.vectorstores import Redis
+
 # from PIL import Image
 from rag_redis.config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
-from langchain_community.document_loaders import ConfluenceLoader
 
 tei_embedding_endpoint = os.getenv("TEI_ENDPOINT")
 confluence_access_token = os.getenv("CONFLUENCE_ACCESS_TOKEN")
 
+
 def wiki_loader(wiki_url, page_ids):
-    loader = ConfluenceLoader(url=wiki_url, token=confluence_access_token, confluence_kwargs={"verify_ssl": False},  )
+    loader = ConfluenceLoader(
+        url=wiki_url,
+        token=confluence_access_token,
+        confluence_kwargs={"verify_ssl": False},
+    )
     print(wiki_url)
     print(page_ids)
-    documents = loader.load(page_ids=page_ids, include_attachments=True, limit=50, max_pages=50)    
+    documents = loader.load(page_ids=page_ids, include_attachments=True, limit=50, max_pages=50)
     return documents
+
 
 def ingest_documents(wiki_url, page_ids):
     """Ingest Wiki Pages to Redis from the variables (wiki_url, page_ids) that
     contains your contents of interest."""
 
-    # Load list of wiki pages 
+    # Load list of wiki pages
     company_name = "Intel"
     print("Parsing Intel wiki pages", page_ids)
     text_splitter = RecursiveCharacterTextSplitter(chunk_size=1500, chunk_overlap=100, add_start_index=True)
     documents = wiki_loader(wiki_url, page_ids)
     content = ""
-    for doc in documents: 
+    for doc in documents:
         content += doc.page_content
     chunks = text_splitter.split_text(content)
 

--- a/ChatQnA/langchain/redis/ingest_wiki.py
+++ b/ChatQnA/langchain/redis/ingest_wiki.py
@@ -27,8 +27,7 @@ from rag_redis.config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
 from langchain_community.document_loaders import ConfluenceLoader
 
 tei_embedding_endpoint = os.getenv("TEI_ENDPOINT")
-# confluence_access_token = os.getenv("CONFLUENCE_ACCESS_TOKEN")
-confluence_access_token = "MzA4Mzc0NTE4MDExOq8IGeVJAXqNN2hSfNbR/tsqFn+D"
+confluence_access_token = os.getenv("CONFLUENCE_ACCESS_TOKEN")
 
 def wiki_loader(wiki_url, page_ids):
     loader = ConfluenceLoader(url=wiki_url, token=confluence_access_token, confluence_kwargs={"verify_ssl": False},  )

--- a/ChatQnA/langchain/redis/ingest_wiki.py
+++ b/ChatQnA/langchain/redis/ingest_wiki.py
@@ -61,7 +61,7 @@ def ingest_documents(wiki_url, page_ids):
         embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
 
     # Batch size
-    batch_size = 32
+    batch_size = 2
     num_chunks = len(chunks)
     for i in range(0, num_chunks, batch_size):
         batch_chunks = chunks[i : i + batch_size]


### PR DESCRIPTION
## Type of Change

feature - add wikiQnA

## Description

Enable WikiQnA to empower enterprise to use internal wiki resources, such as Intel EnterpriseWiki. Access token is passed from environment variable with on premise deployment to safeguard customer's secrets. 

## How has this PR been tested?

It's tested on Intel Enterprise Wiki information RAG. 

## Dependency Change?

Add "atlassian-python-api" library to support Enterprise Wiki read using wiki_url and page_ids. 
