### PR TITLE
Update Readme.md for clarity, security group and curl command

### DIFF
--- a/ChatQnA/docker-composer/xeon/README.md
+++ b/ChatQnA/docker-composer/xeon/README.md
@@ -10,6 +10,53 @@ For detailed information about these instance types, you can refer to this [link
 
 After launching your instance, you can connect to it using SSH (for Linux instances) or Remote Desktop Protocol (RDP) (for Windows instances). From there, you'll have full access to your Xeon server, allowing you to install, configure, and manage your applications as needed.
 
+**Certain ports in the EC2 instance need to opened up in the security group, for the microservices to work with the curl commands**
+
+> See one example below. Please open up these ports in the EC2 instance based on the IP addresses you want to allow
+
+```
+redis-vector-db
+===============
+Port 6379 - Open to 0.0.0.0/0
+Port 8001 - Open to 0.0.0.0/0
+
+tei_embedding_service
+=====================
+Port 6006 - Open to 0.0.0.0/0
+
+embedding
+=========
+Port 6000 - Open to 0.0.0.0/0
+
+retriever
+=========
+Port 7000 - Open to 0.0.0.0/0
+
+tei_xeon_service
+================
+Port 8808 - Open to 0.0.0.0/0
+
+reranking
+=========
+Port 8000 - Open to 0.0.0.0/0
+
+tgi_service
+===========
+Port 9009 - Open to 0.0.0.0/0
+
+llm
+===
+Port 9000 - Open to 0.0.0.0/0
+
+chaqna-xeon-backend-server
+==========================
+Port 8888 - Open to 0.0.0.0/0
+
+chaqna-xeon-ui-server
+=====================
+Port 5173 - Open to 0.0.0.0/0
+```
+
 ## 🚀 Build Docker Images
 
 First of all, you need to build Docker Images locally and install the python package of it.
@@ -84,6 +131,19 @@ Then run the command `docker images`, you will have the following four Docker Im
 
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below.
 
+**Export the value of the public IP address of your Xeon server to the `host_ip` environment variable**
+> Change the External_Public_IP below with the actual IPV4 value
+```
+export host_ip="External_Public_IP"
+```
+
+**Export the value of your Huggingface API token to the `your_hf_api_token` environment variable**
+> Change the Your_Huggingface_API_Token below with tyour actual Huggingface API Token value
+```
+export your_hf_api_token="Your_Huggingface_API_Token"
+```
+
+
 ```bash
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
@@ -107,6 +167,11 @@ export BACKEND_SERVICE_ENDPOINT="http://${host_ip}:8888/v1/chatqna"
 Note: Please replace with `host_ip` with you external IP address, do not use localhost.
 
 ### Start all the services Docker Containers
+> Before running the docker compose command, you need to be in the `/home/ubuntu/GenAIComps/GenAIExamples/ChatQnA/microservice/xeon` folder
+
+```
+cd /home/ubuntu/GenAIComps/GenAIExamples/ChatQnA/microservice/xeon
+```
 
 ```bash
 cd GenAIExamples/ChatQnA/docker-composer/xeon/
@@ -145,9 +210,9 @@ print(embedding)
 Then substitute your mock embedding vector for the `${your_embedding}` in the following cURL command:
 
 ```bash
-curl http://${host_ip}:7000/v1/retrieval\
+curl http://${host_ip}:7000/v1/retrieval \
   -X POST \
-  -d '{"text":"What is the revenue of Nike in 2023?","embedding":${your_embedding}}' \
+  -d '{"text":"What is the revenue of Nike in 2023?","embedding":"'"${your_embedding}"'"}' \
   -H 'Content-Type: application/json'
 ```
 

--- a/ChatQnA/docker-composer/xeon/README.md
+++ b/ChatQnA/docker-composer/xeon/README.md
@@ -167,11 +167,8 @@ export BACKEND_SERVICE_ENDPOINT="http://${host_ip}:8888/v1/chatqna"
 Note: Please replace with `host_ip` with you external IP address, do not use localhost.
 
 ### Start all the services Docker Containers
-> Before running the docker compose command, you need to be in the `/home/ubuntu/GenAIComps/GenAIExamples/ChatQnA/microservice/xeon` folder
+> Before running the docker compose command, you need to be in the correct folder that has the docker_compose.yaml file
 
-```
-cd /home/ubuntu/GenAIComps/GenAIExamples/ChatQnA/microservice/xeon
-```
 
 ```bash
 cd GenAIExamples/ChatQnA/docker-composer/xeon/

--- a/ChatQnA/docker-composer/xeon/README.md
+++ b/ChatQnA/docker-composer/xeon/README.md
@@ -132,17 +132,20 @@ Then run the command `docker images`, you will have the following four Docker Im
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below.
 
 **Export the value of the public IP address of your Xeon server to the `host_ip` environment variable**
+
 > Change the External_Public_IP below with the actual IPV4 value
+
 ```
 export host_ip="External_Public_IP"
 ```
 
 **Export the value of your Huggingface API token to the `your_hf_api_token` environment variable**
+
 > Change the Your_Huggingface_API_Token below with tyour actual Huggingface API Token value
+
 ```
 export your_hf_api_token="Your_Huggingface_API_Token"
 ```
-
 
 ```bash
 export http_proxy=${your_http_proxy}
@@ -167,7 +170,8 @@ export BACKEND_SERVICE_ENDPOINT="http://${host_ip}:8888/v1/chatqna"
 Note: Please replace with `host_ip` with you external IP address, do not use localhost.
 
 ### Start all the services Docker Containers
-> Before running the docker compose command, you need to be in the correct folder that has the docker_compose.yaml file
+
+> Before running the docker compose command, you need to be in the `/home/ubuntu/GenAIComps/GenAIExamples/ChatQnA/microservice/xeon` folder
 
 
 ```bash

--- a/ChatQnA/docker-composer/xeon/README.md
+++ b/ChatQnA/docker-composer/xeon/README.md
@@ -171,7 +171,7 @@ Note: Please replace with `host_ip` with you external IP address, do not use loc
 
 ### Start all the services Docker Containers
 
-> Before running the docker compose command, you need to be in the `/home/ubuntu/GenAIComps/GenAIExamples/ChatQnA/microservice/xeon` folder
+> Before running the docker compose command, you need to be in the folder that has the docker compose yaml file
 
 
 ```bash


### PR DESCRIPTION
## Description

1. Added instructions for populating environment variables host_ip and your_hf_api_token. This elps to run the other export commands as is and not to change in multiple places
2. The docker compose yaml file is in the folder location `/home/ubuntu/GenAIComps/GenAIExamples/ChatQnA/microservice/xeon`. Added instruction to navigate to this folder location before running the docker compose command
3. For testing in m7i EC2 instance in AWS, certain ports in the security group needs to be opened up. Otherwise the communication to the microservices using curl commands do not work. Added the instruction in the Readme.md

## Issues

Issues - https://github.com/opea-project/GenAIExamples/issues/155.

Issues - https://github.com/opea-project/GenAIExamples/issues/157

Other confusions encountered in testing this example have been updated in Readme.md mentioned in PR.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

I have tested the ChatQnA example for Xeon on m7i.8xlarge EC2 instance in AWS. I have also tested using the chat UI on http://public_IP:5173. It works fine.
