### PR TITLE
Change pre-commit-config to support helm charts and k8s manifest yamls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
               DocSum/ui/svelte/tsconfig.json
           )$
       - id: check-yaml
+        args: [--allow-multiple-documents]
       - id: debug-statements
       - id: requirements-txt-fixer
       - id: trailing-whitespace

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+**/kubernetes/


### PR DESCRIPTION
## Description

To support helm charts and k8s manifest yamls, change pre-commit-config to allow multiple documents for yaml and change prettier to ignore k8s related yaml files.

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

n/a
