### PR TITLE
Fixed incorrect cd command in README

### DIFF
--- a/CodeGen/docker/gaudi/README.md
+++ b/CodeGen/docker/gaudi/README.md
@@ -34,7 +34,7 @@ docker build -t opea/codegen:latest --build-arg https_proxy=$https_proxy --build
 Construct the frontend Docker image via the command below:
 
 ```bash
-cd GenAIExamples/CodeGen/ui/
+cd GenAIExamples/CodeGen/docker/ui/
 docker build -t opea/codegen-ui:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f ./docker/Dockerfile .
 ```
 


### PR DESCRIPTION
Changed cd GenAIExamples/CodeGen/ui/ to cd GenAIExamples/CodeGen/docker/ui/. As the ui directory is in the docker directory.


