### PR TITLE
Add no_proxy env for embedding-tei-server container

### DIFF
--- a/ChatQnA/docker/gaudi/README.md
+++ b/ChatQnA/docker/gaudi/README.md
@@ -90,6 +90,7 @@ Then run the command `docker images`, you will have the following 8 Docker Image
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below.
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export EMBEDDING_MODEL_ID="BAAI/bge-base-en-v1.5"

--- a/ChatQnA/docker/gaudi/docker_compose.yaml
+++ b/ChatQnA/docker/gaudi/docker_compose.yaml
@@ -19,6 +19,7 @@ services:
     ports:
       - "6007:6007"
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
@@ -35,6 +36,7 @@ services:
       - SYS_NICE
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       HABANA_VISIBLE_DEVICES: all
@@ -49,6 +51,7 @@ services:
       - "6000:6000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
@@ -65,6 +68,7 @@ services:
       - "7000:7000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
@@ -82,6 +86,7 @@ services:
       - "./data:/data"
     shm_size: 1g
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
     command: --model-id ${RERANK_MODEL_ID}
@@ -94,6 +99,7 @@ services:
       - "8000:8000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TEI_RERANKING_ENDPOINT: ${TEI_RERANKING_ENDPOINT}
@@ -110,6 +116,7 @@ services:
     volumes:
       - "./data:/data"
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       HF_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
@@ -129,6 +136,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -152,6 +160,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -169,6 +178,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - CHAT_BASE_URL=${BACKEND_SERVICE_ENDPOINT}

--- a/ChatQnA/docker/xeon/README.md
+++ b/ChatQnA/docker/xeon/README.md
@@ -148,6 +148,7 @@ export your_hf_api_token="Your_Huggingface_API_Token"
 ```
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export EMBEDDING_MODEL_ID="BAAI/bge-base-en-v1.5"

--- a/ChatQnA/docker/xeon/docker_compose.yaml
+++ b/ChatQnA/docker/xeon/docker_compose.yaml
@@ -19,6 +19,7 @@ services:
     ports:
       - "6007:6007"
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
@@ -32,6 +33,7 @@ services:
       - "./data:/data"
     shm_size: 1g
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
     command: --model-id ${EMBEDDING_MODEL_ID}
@@ -44,6 +46,7 @@ services:
       - "6000:6000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
@@ -60,6 +63,7 @@ services:
       - "7000:7000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
@@ -78,6 +82,7 @@ services:
       - "./data:/data"
     shm_size: 1g
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
     command: --model-id ${RERANK_MODEL_ID}
@@ -90,6 +95,7 @@ services:
       - "8000:8000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TEI_RERANKING_ENDPOINT: ${TEI_RERANKING_ENDPOINT}
@@ -107,6 +113,7 @@ services:
       - "./data:/data"
     shm_size: 1g
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       HF_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
@@ -120,6 +127,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -143,6 +151,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -160,6 +169,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - CHAT_BASE_URL=${BACKEND_SERVICE_ENDPOINT}

--- a/CodeGen/docker/gaudi/README.md
+++ b/CodeGen/docker/gaudi/README.md
@@ -51,6 +51,7 @@ Then run the command `docker images`, you will have the following 3 Docker image
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below.
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export LLM_MODEL_ID="meta-llama/CodeLlama-7b-hf"

--- a/CodeGen/docker/gaudi/docker_compose.yaml
+++ b/CodeGen/docker/gaudi/docker_compose.yaml
@@ -13,6 +13,7 @@ services:
     volumes:
       - "./data:/data"
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       HABANA_VISIBLE_DEVICES: all
@@ -32,6 +33,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -48,6 +50,7 @@ services:
     ports:
       - "7778:7778"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -62,6 +65,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - BASIC_URL=${BACKEND_SERVICE_ENDPOINT}

--- a/CodeGen/docker/xeon/README.md
+++ b/CodeGen/docker/xeon/README.md
@@ -59,6 +59,7 @@ Then run the command `docker images`, you will have the following 3 Docker Image
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below.
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export LLM_MODEL_ID="meta-llama/CodeLlama-7b-hf"

--- a/CodeGen/docker/xeon/docker_compose.yaml
+++ b/CodeGen/docker/xeon/docker_compose.yaml
@@ -14,6 +14,7 @@ services:
       - "./data:/data"
     shm_size: 1g
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       HF_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
@@ -27,6 +28,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -43,6 +45,7 @@ services:
     ports:
       - "7778:7778"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -57,6 +60,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - BASIC_URL=${BACKEND_SERVICE_ENDPOINT}

--- a/CodeTrans/docker/gaudi/README.md
+++ b/CodeTrans/docker/gaudi/README.md
@@ -47,6 +47,7 @@ Then run the command `docker images`, you will have the following Docker Images:
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below. Notice that the `LLM_MODEL_ID` indicates the LLM model used for TGI service.
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export LLM_MODEL_ID="HuggingFaceH4/mistral-7b-grok"

--- a/CodeTrans/docker/gaudi/docker_compose.yaml
+++ b/CodeTrans/docker/gaudi/docker_compose.yaml
@@ -13,6 +13,7 @@ services:
     volumes:
       - "./data:/data"
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       HABANA_VISIBLE_DEVICES: all
@@ -30,6 +31,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -47,6 +49,7 @@ services:
     ports:
       - "7777:7777"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -61,6 +64,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - BASE_URL=${BACKEND_SERVICE_ENDPOINT}

--- a/CodeTrans/docker/xeon/README.md
+++ b/CodeTrans/docker/xeon/README.md
@@ -55,6 +55,7 @@ Then run the command `docker images`, you will have the following Docker Images:
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below. Notice that the `LLM_MODEL_ID` indicates the LLM model used for TGI service.
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export LLM_MODEL_ID="HuggingFaceH4/mistral-7b-grok"

--- a/CodeTrans/docker/xeon/docker_compose.yaml
+++ b/CodeTrans/docker/xeon/docker_compose.yaml
@@ -14,6 +14,7 @@ services:
       - "./data:/data"
     shm_size: 1g
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       HF_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
@@ -25,6 +26,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -42,6 +44,7 @@ services:
     ports:
       - "7777:7777"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -56,6 +59,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - BASE_URL=${BACKEND_SERVICE_ENDPOINT}

--- a/DocSum/docker/gaudi/README.md
+++ b/DocSum/docker/gaudi/README.md
@@ -58,6 +58,7 @@ Then run the command `docker images`, you will have the following Docker Images:
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below.
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export LLM_MODEL_ID="Intel/neural-chat-7b-v3-3"

--- a/DocSum/docker/gaudi/docker_compose.yaml
+++ b/DocSum/docker/gaudi/docker_compose.yaml
@@ -11,6 +11,7 @@ services:
     ports:
       - "8008:80"
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -31,6 +32,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -48,6 +50,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -62,6 +65,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - DOC_BASE_URL=${BACKEND_SERVICE_ENDPOINT}

--- a/DocSum/docker/xeon/README.md
+++ b/DocSum/docker/xeon/README.md
@@ -59,6 +59,7 @@ Then run the command `docker images`, you will have the following Docker Images:
 Since the `docker_compose.yaml` will consume some environment variables, you need to setup them in advance as below.
 
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export LLM_MODEL_ID="Intel/neural-chat-7b-v3-3"

--- a/DocSum/docker/xeon/docker_compose.yaml
+++ b/DocSum/docker/xeon/docker_compose.yaml
@@ -11,6 +11,7 @@ services:
     ports:
       - "8008:80"
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -28,6 +29,7 @@ services:
       - "9000:9000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
@@ -45,6 +47,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -59,6 +62,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - DOC_BASE_URL=${BACKEND_SERVICE_ENDPOINT}


### PR DESCRIPTION
## Description

Add no_proxy env for embedding-tei-server container

## Issues

In a proxy r&d or deployment environment ( need proxy to access external network, no proxy to access internal network)
we need to pass no_proxy setting to embedding-tei-server, otherwise by following https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/docker/xeon/README.md

"TEI embedding service" access is OK, but inside "Embedding Microservice", it failed to access "Embedding Microservice".
some discussion in https://github.com/opea-project/GenAIExamples/issues/251

TEI Embedding Service
curl ${host_ip}:6006/embed
-X POST
-d '{"inputs":"What is Deep Learning?"}'
-H 'Content-Type: application/json'
Embedding Microservice
curl http://${host_ip}:6000/v1/embeddings
-X POST
-d '{"text":"hello"}'
-H 'Content-Type: application/json'

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

[List the newly introduced 3rd party dependency if exists.]



## Tests

Follow (https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/docker/xeon/README.md) to set up ChatQnA in a proxy environment

without this patch and https://github.com/opea-project/GenAIComps/pull/140
TEI Embedding Service ok
curl ${host_ip}:6006/embed
-X POST
-d '{"inputs":"What is Deep Learning?"}'
-H 'Content-Type: application/json'
Embedding Microservice ko
curl http://${host_ip}:6000/v1/embeddings
-X POST
-d '{"text":"hello"}'
-H 'Content-Type: application/json'