### PR TITLE
Add correct ip to no_proxy list, and add no_proxy env for embedding and reranking containers

### DIFF
--- a/ChatQnA/docker/xeon/README.md
+++ b/ChatQnA/docker/xeon/README.md
@@ -151,6 +151,7 @@ export your_hf_api_token="Your_Huggingface_API_Token"
 ```
 
 **Append the value of the public IP address to the no_proxy list**
+
 ```
 export your_no_proxy=${your_no_proxy},"External_Public_IP"
 ```

--- a/ChatQnA/docker/xeon/README.md
+++ b/ChatQnA/docker/xeon/README.md
@@ -150,7 +150,13 @@ export host_ip="External_Public_IP"
 export your_hf_api_token="Your_Huggingface_API_Token"
 ```
 
+**Append the value of the public IP address to the no_proxy list**
+```
+export your_no_proxy=${your_no_proxy},"External_Public_IP"
+```
+
 ```bash
+export no_proxy=${your_no_proxy}
 export http_proxy=${your_http_proxy}
 export https_proxy=${your_http_proxy}
 export EMBEDDING_MODEL_ID="BAAI/bge-base-en-v1.5"

--- a/ChatQnA/docker/xeon/docker_compose.yaml
+++ b/ChatQnA/docker/xeon/docker_compose.yaml
@@ -44,6 +44,7 @@ services:
       - "6000:6000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
@@ -90,6 +91,7 @@ services:
       - "8000:8000"
     ipc: host
     environment:
+      no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TEI_RERANKING_ENDPOINT: ${TEI_RERANKING_ENDPOINT}
@@ -143,6 +145,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - MEGA_SERVICE_HOST_IP=${MEGA_SERVICE_HOST_IP}
@@ -160,6 +163,7 @@ services:
     ports:
       - "5173:5173"
     environment:
+      - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - CHAT_BASE_URL=${BACKEND_SERVICE_ENDPOINT}


### PR DESCRIPTION
## Description

Add no_proxy env for embedding-tei-server container

Append host_ip to the no_proxy list

## Issues
We need to pass no_proxy setting to embedding and reranking microservices. As in the PR below
(https://github.com/opea-project/GenAIExamples/pull/267)

Also, we need to append host_ip, the public host ipv4 address, to the no_proxy list stored in the no_proxy variable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.
(https://github.com/opea-project/GenAIComps/pull/140)
(https://github.com/opea-project/GenAIExamples/pull/267)

## Tests

With this patch,

Embedding Microservice ok
curl http://${host_ip}:6000/v1/embeddings
-X POST
-d '{"text":"hello"}'
-H 'Content-Type: application/json'

Reranking Microservice ok
curl http://${host_ip}:8000/v1/reranking\
  -X POST \
  -d '{"initial_query":"What is Deep Learning?", "retrieved_docs": [{"text":"Deep Learning is not..."}, {"text":"Deep learning is..."}]}' \
  -H 'Content-Type: application/json'
