### PR TITLE
Enable building latest megaservice image on push event in CI

### DIFF
--- a/.github/workflows/image-build-on-push.yml
+++ b/.github/workflows/image-build-on-push.yml
@@ -1,0 +1,30 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+# Test
+name: Build latest images on push event
+
+on:
+  push:
+    branches: [ 'main' ]
+    paths:
+      - "**/docker/*.py"
+      - "**/docker/Dockerfile"
+      - "**/docker/ui/**"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-on-push
+  cancel-in-progress: true
+
+jobs:
+  job1:
+    uses: ./.github/workflows/reuse-get-test-matrix.yml
+
+  mega-image-build:
+    needs: job1
+    strategy:
+      matrix: ${{ fromJSON(needs.job1.outputs.run_matrix) }}
+    uses: ./.github/workflows/reuse-image-build.yml
+    with:
+      image-tag: latest
+      mega-service: "${{ matrix.example }}"

--- a/.github/workflows/manifest-e2e.yml
+++ b/.github/workflows/manifest-e2e.yml
@@ -23,7 +23,7 @@ jobs:
   job1:
     uses: ./.github/workflows/reuse-get-test-matrix.yml
     with:
-      diff-excluded-files: '.github|deprecated|docker|assets'
+      diff-excluded-files: '.github|deprecated|docker|assets|*.md|*.txt'
       xeon-server-lable: 'k8s'
       gaudi-server-lable: ""
 

--- a/.github/workflows/reuse-get-test-matrix.yml
+++ b/.github/workflows/reuse-get-test-matrix.yml
@@ -1,6 +1,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+# Support push and pull_request events
 name: Get Test Matrix
 permissions: read-all
 on:
@@ -30,18 +31,32 @@ jobs:
     outputs:
       run_matrix: ${{ steps.get-test-matrix.outputs.run_matrix }}
     steps:
+      - name: Get checkout ref
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
+            echo "CHECKOUT_REF=refs/pull/${{ github.event.number }}/merge" >> $GITHUB_ENV
+          else
+            echo "CHECKOUT_REF=${{ github.ref }}" >> $GITHUB_ENV
+          fi
+          echo "checkout ref ${{ env.CHECKOUT_REF }}"
+
       - name: Checkout out Repo
         uses: actions/checkout@v4
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: ${{ env.CHECKOUT_REF }}
           fetch-depth: 0
 
       - name: Get test matrix
         id: get-test-matrix
         run: |
           set -xe
+          if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
+            base_commit=${{ github.event.pull_request.base.sha }}
+          else
+            base_commit=$(git rev-parse HEAD~1) # push event
+          fi
           merged_commit=$(git log -1 --format='%H')
-          changed_files="$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${merged_commit} | \
+          changed_files="$(git diff --name-only ${base_commit} ${merged_commit} | \
           grep -vE '${{ inputs.diff-excluded-files }}')" || true
           examples=$(printf '%s\n' "${changed_files[@]}" | grep '/' | cut -d'/' -f1 | sort -u)
           run_matrix="{\"include\":["
@@ -51,7 +66,7 @@ jobs:
               if [ $(printf '%s\n' "${changed_files[@]}" | grep ${example} | grep -c xeon) != 0 ]; then run_hardware="xeon ${run_hardware}"; fi
               if [ "$run_hardware" = "" ]; then run_hardware="xeon"; fi
               for hw in ${run_hardware}; do
-                  if [ $hw = "gaudi" && ${{ inputs.gaudi-server-lable }} != ""]; then
+                  if [ $hw = "gaudi" ] && [ ${{ inputs.gaudi-server-lable }} != ""]; then
                     run_matrix="${run_matrix}{\"example\":\"${example}\",\"hardware\":\"${{ inputs.gaudi-server-lable }}\"},"
                   elif [ ${{ inputs.xeon-server-lable }} != "" ]; then
                     run_matrix="${run_matrix}{\"example\":\"${example}\",\"hardware\":\"${{ inputs.xeon-server-lable }}\"},"


### PR DESCRIPTION
## Description

Enable building latest megaservice image on push event in CI and pushing it to image registry

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

n/a
