### PR TITLE
Fix missing Dockerfiles path in GenAIComps

### DIFF
--- a/.github/workflows/reuse-get-test-matrix.yml
+++ b/.github/workflows/reuse-get-test-matrix.yml
@@ -64,11 +64,11 @@ jobs:
               run_hardware=""
               if [ $(printf '%s\n' "${changed_files[@]}" | grep ${example} | grep -c gaudi) != 0 ]; then run_hardware="gaudi"; fi
               if [ $(printf '%s\n' "${changed_files[@]}" | grep ${example} | grep -c xeon) != 0 ]; then run_hardware="xeon ${run_hardware}"; fi
-              if [ "$run_hardware" = "" ]; then run_hardware="xeon"; fi
+              if [ "$run_hardware" == "" ]; then run_hardware="xeon"; fi
               for hw in ${run_hardware}; do
-                  if [ $hw = "gaudi" ] && [ ${{ inputs.gaudi-server-lable }} != ""]; then
+                  if [ "$hw" == "gaudi" && "${{ inputs.gaudi-server-lable }}" != ""]; then
                     run_matrix="${run_matrix}{\"example\":\"${example}\",\"hardware\":\"${{ inputs.gaudi-server-lable }}\"},"
-                  elif [ ${{ inputs.xeon-server-lable }} != "" ]; then
+                  elif [ "${{ inputs.xeon-server-lable }}" != "" ]; then
                     run_matrix="${run_matrix}{\"example\":\"${example}\",\"hardware\":\"${{ inputs.xeon-server-lable }}\"},"
                   fi
               done

--- a/ChatQnA/docker/gaudi/README.md
+++ b/ChatQnA/docker/gaudi/README.md
@@ -22,7 +22,7 @@ docker build --no-cache -t opea/embedding-tei:latest --build-arg https_proxy=$ht
 ### 3. Build Retriever Image
 
 ```bash
-docker build --no-cache -t opea/retriever-redis:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/retrievers/langchain/docker/Dockerfile .
+docker build --no-cache -t opea/retriever-redis:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/retrievers/langchain/redis/docker/Dockerfile .
 ```
 
 ### 4. Build Rerank Image

--- a/ChatQnA/docker/xeon/README.md
+++ b/ChatQnA/docker/xeon/README.md
@@ -75,7 +75,7 @@ docker build --no-cache -t opea/embedding-tei:latest --build-arg https_proxy=$ht
 ### 2. Build Retriever Image
 
 ```bash
-docker build --no-cache -t opea/retriever-redis:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/retrievers/langchain/docker/Dockerfile .
+docker build --no-cache -t opea/retriever-redis:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/retrievers/langchain/redis/docker/Dockerfile .
 ```
 
 ### 3. Build Rerank Image

--- a/ChatQnA/tests/test_chatqna_on_gaudi.sh
+++ b/ChatQnA/tests/test_chatqna_on_gaudi.sh
@@ -14,7 +14,7 @@ function build_docker_images() {
     cd GenAIComps
 
     docker build -t opea/embedding-tei:latest -f comps/embeddings/langchain/docker/Dockerfile .
-    docker build -t opea/retriever-redis:latest -f comps/retrievers/langchain/docker/Dockerfile .
+    docker build -t opea/retriever-redis:latest -f comps/retrievers/langchain/redis/docker/Dockerfile .
     docker build -t opea/reranking-tei:latest -f comps/reranks/langchain/docker/Dockerfile .
     docker build -t opea/llm-tgi:latest -f comps/llms/text-generation/tgi/Dockerfile .
     docker build -t opea/dataprep-redis:latest -f comps/dataprep/redis/langchain/docker/Dockerfile .

--- a/ChatQnA/tests/test_chatqna_on_xeon.sh
+++ b/ChatQnA/tests/test_chatqna_on_xeon.sh
@@ -14,7 +14,7 @@ function build_docker_images() {
     cd GenAIComps
 
     docker build -t opea/embedding-tei:latest -f comps/embeddings/langchain/docker/Dockerfile .
-    docker build -t opea/retriever-redis:latest -f comps/retrievers/langchain/docker/Dockerfile .
+    docker build -t opea/retriever-redis:latest -f comps/retrievers/langchain/redis/docker/Dockerfile .
     docker build -t opea/reranking-tei:latest -f comps/reranks/langchain/docker/Dockerfile .
     docker build -t opea/llm-tgi:latest -f comps/llms/text-generation/tgi/Dockerfile .
     docker build -t opea/dataprep-redis:latest -f comps/dataprep/redis/langchain/docker/Dockerfile .


### PR DESCRIPTION
## Description

Fix missing Dockerfiles path `comps/retrievers/langchain/docker/Dockerfile` in GenAIComps

## Issues

Two errors reported by check-dockerfile-paths in CI:
```
Missing Dockerfile: GenAIComps/comps/retrievers/langchain/docker/Dockerfile (Referenced in GenAIExamples/./ChatQnA/docker/gaudi/README.md:25)
Missing Dockerfile: GenAIComps/comps/retrievers/langchain/docker/Dockerfile (Referenced in GenAIExamples/./ChatQnA/docker/xeon/README.md:78)
```

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

n/a

## Tests

CI Tests
