### PR TITLE
Modular data services

### DIFF
--- a/ChatQnA/docker/aipc/docker_compose.yaml
+++ b/ChatQnA/docker/aipc/docker_compose.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 
 include:
- - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+ - ../data-service/${DATA_SERVICE:-redis}/docker-compose.yaml
 
 services:
   tei-embedding-service:

--- a/ChatQnA/docker/aipc/docker_compose.yaml
+++ b/ChatQnA/docker/aipc/docker_compose.yaml
@@ -3,26 +3,10 @@
 
 version: "3.8"
 
+include:
+ - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+
 services:
-  redis-vector-db:
-    image: redis/redis-stack:7.2.0-v9
-    container_name: redis-vector-db
-    ports:
-      - "6379:6379"
-      - "8001:8001"
-  dataprep-redis-service:
-    image: opea/dataprep-redis:latest
-    container_name: dataprep-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "6007:6007"
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-embedding-server
@@ -52,25 +36,6 @@ services:
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
       LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
       LANGCHAIN_PROJECT: "opea-embedding-service"
-    restart: unless-stopped
-  retriever:
-    image: opea/retriever-redis:latest
-    container_name: retriever-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "7000:7000"
-    ipc: host
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
-      TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
-      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
-      LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
-      LANGCHAIN_PROJECT: "opea-retriever-service"
     restart: unless-stopped
   tei-reranking-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2

--- a/ChatQnA/docker/data-service/pgvector/docker-compose.yaml
+++ b/ChatQnA/docker/data-service/pgvector/docker-compose.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   pgvector-vector-db:
     container_name: pgvector-vector-db
@@ -13,7 +16,7 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
-    
+
   dataprep-service:
     image: opea/dataprep-pgvector:latest
     container_name: dataprep-pgvector
@@ -26,7 +29,7 @@ services:
       PG_CONNECTION_STRING: ${PG_CONNECTION_STRING}
       INDEX_NAME: ${INDEX_NAME}
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
-  
+
   retriever:
     image: opea/retriever-pgvector:latest
     container_name: retriever-pgvector

--- a/ChatQnA/docker/data-service/pgvector/docker-compose.yaml
+++ b/ChatQnA/docker/data-service/pgvector/docker-compose.yaml
@@ -1,0 +1,46 @@
+services:
+  pgvector-vector-db:
+    container_name: pgvector-vector-db
+    image: pgvector/pgvector:0.7.0-pg16
+    ports:
+      - "5432:5432"
+    restart: always
+    ipc: host
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_HOST_AUTH_METHOD=trust
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    
+  dataprep-service:
+    image: opea/dataprep-pgvector:latest
+    container_name: dataprep-pgvector
+    ports:
+      - "6007:6007"
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      PG_CONNECTION_STRING: ${PG_CONNECTION_STRING}
+      INDEX_NAME: ${INDEX_NAME}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
+  
+  retriever:
+    image: opea/retriever-pgvector:latest
+    container_name: retriever-pgvector
+    depends_on:
+      - pgvector-vector-db
+    ports:
+      - "7000:7000"
+    ipc: host
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      PG_CONNECTION_STRING: ${PG_CONNECTION_STRING}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
+      LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
+      LANGCHAIN_PROJECT: "opea-retriever-service"
+    restart: unless-stopped

--- a/ChatQnA/docker/data-service/qdrant/docker-compose.yaml
+++ b/ChatQnA/docker/data-service/qdrant/docker-compose.yaml
@@ -1,0 +1,38 @@
+services:
+  qdrant-vector-db:
+    image: qdrant/qdrant
+    container_name: qdrant-vector-db
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+  dataprep-qdrant-service:
+    image: opea/dataprep-qdrant:latest
+    container_name: dataprep-qdrant-server
+    depends_on:
+      - qdrant-vector-db
+    ports:
+      - "6000:6000"
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      QDRANT: ${host_ip}
+      QDRANT_PORT: 6333
+      COLLECTION_NAME: ${INDEX_NAME}
+  retriever:
+    image: opea/retriever-qdrant:latest
+    container_name: retriever-qdrant-server
+    depends_on:
+      - qdrant-vector-db
+    ports:
+      - "7000:7000"
+    ipc: host
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      QDRANT_HOST: ${host_ip}
+      QDRANT_PORT: 6333
+      INDEX_NAME: ${INDEX_NAME}
+      TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+    restart: unless-stopped

--- a/ChatQnA/docker/data-service/qdrant/docker-compose.yaml
+++ b/ChatQnA/docker/data-service/qdrant/docker-compose.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   qdrant-vector-db:
     image: qdrant/qdrant

--- a/ChatQnA/docker/data-service/redis/docker-compose.yaml
+++ b/ChatQnA/docker/data-service/redis/docker-compose.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 services:
   redis-vector-db:
     image: redis/redis-stack:7.2.0-v9

--- a/ChatQnA/docker/data-service/redis/docker-compose.yaml
+++ b/ChatQnA/docker/data-service/redis/docker-compose.yaml
@@ -1,0 +1,41 @@
+services:
+  redis-vector-db:
+    image: redis/redis-stack:7.2.0-v9
+    container_name: redis-vector-db
+    ports:
+      - "6379:6379"
+      - "8001:8001"
+  dataprep-redis-service:
+    image: opea/dataprep-redis:latest
+    container_name: dataprep-redis-server
+    depends_on:
+      - redis-vector-db
+    ports:
+      - "6007:6007"
+      - "6008:6008"
+      - "6009:6009"
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      REDIS_URL: ${REDIS_URL}
+      INDEX_NAME: ${INDEX_NAME}
+  retriever:
+    image: opea/retriever-redis:latest
+    container_name: retriever-redis-server
+    depends_on:
+      - redis-vector-db
+    ports:
+      - "7000:7000"
+    ipc: host
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      REDIS_URL: ${REDIS_URL}
+      INDEX_NAME: ${INDEX_NAME}
+      TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
+      LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
+      LANGCHAIN_PROJECT: "opea-retriever-service"
+    restart: unless-stopped

--- a/ChatQnA/docker/gaudi/docker_compose.yaml
+++ b/ChatQnA/docker/gaudi/docker_compose.yaml
@@ -5,7 +5,7 @@
 version: "3.8"
 
 include:
- - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+ - ../data-service/${DATA_SERVICE:-redis}/docker-compose.yaml
 
 services:
   tei-embedding-service:

--- a/ChatQnA/docker/gaudi/docker_compose.yaml
+++ b/ChatQnA/docker/gaudi/docker_compose.yaml
@@ -4,28 +4,10 @@
 
 version: "3.8"
 
+include:
+ - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+
 services:
-  redis-vector-db:
-    image: redis/redis-stack:7.2.0-v9
-    container_name: redis-vector-db
-    ports:
-      - "6379:6379"
-      - "8001:8001"
-  dataprep-redis-service:
-    image: opea/dataprep-redis:latest
-    container_name: dataprep-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "6007:6007"
-      - "6008:6008"
-      - "6009:6009"
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server
@@ -61,24 +43,6 @@ services:
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
       LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
       LANGCHAIN_PROJECT: "opea-embedding-service"
-    restart: unless-stopped
-  retriever:
-    image: opea/retriever-redis:latest
-    container_name: retriever-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "7000:7000"
-    ipc: host
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
-      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
-      LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
-      LANGCHAIN_PROJECT: "opea-retriever-service"
     restart: unless-stopped
   tei-reranking-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2

--- a/ChatQnA/docker/gaudi/docker_compose_guardrails.yaml
+++ b/ChatQnA/docker/gaudi/docker_compose_guardrails.yaml
@@ -4,28 +4,10 @@
 
 version: "3.8"
 
+include:
+ - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+
 services:
-  redis-vector-db:
-    image: redis/redis-stack:7.2.0-v9
-    container_name: redis-vector-db
-    ports:
-      - "6379:6379"
-      - "8001:8001"
-  dataprep-redis-service:
-    image: opea/dataprep-redis:latest
-    container_name: dataprep-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "6007:6007"
-      - "6008:6008"
-      - "6009:6009"
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
   tgi-guardrails-service:
     image: ghcr.io/huggingface/tgi-gaudi:2.0.1
     container_name: tgi-guardrails-server
@@ -97,24 +79,6 @@ services:
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
       LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
       LANGCHAIN_PROJECT: "opea-embedding-service"
-    restart: unless-stopped
-  retriever:
-    image: opea/retriever-redis:latest
-    container_name: retriever-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "7000:7000"
-    ipc: host
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
-      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
-      LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
-      LANGCHAIN_PROJECT: "opea-retriever-service"
     restart: unless-stopped
   tei-reranking-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2

--- a/ChatQnA/docker/gaudi/docker_compose_guardrails.yaml
+++ b/ChatQnA/docker/gaudi/docker_compose_guardrails.yaml
@@ -5,7 +5,7 @@
 version: "3.8"
 
 include:
- - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+ - ../data-service/${DATA_SERVICE:-redis}/docker-compose.yaml
 
 services:
   tgi-guardrails-service:

--- a/ChatQnA/docker/gpu/docker_compose.yaml
+++ b/ChatQnA/docker/gpu/docker_compose.yaml
@@ -5,7 +5,7 @@
 version: "3.8"
 
 include:
- - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+ - ../data-service/${DATA_SERVICE:-redis}/docker-compose.yaml
 
 services:
   tei-embedding-service:

--- a/ChatQnA/docker/gpu/docker_compose.yaml
+++ b/ChatQnA/docker/gpu/docker_compose.yaml
@@ -4,28 +4,10 @@
 
 version: "3.8"
 
+include:
+ - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+
 services:
-  redis-vector-db:
-    image: redis/redis-stack:7.2.0-v9
-    container_name: redis-vector-db
-    ports:
-      - "6379:6379"
-      - "8001:8001"
-  dataprep-redis-service:
-    image: opea/dataprep-redis:latest
-    container_name: dataprep-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "6007:6007"
-      - "6008:6008"
-      - "6009:6009"
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:1.2
     container_name: tei-embedding-server
@@ -63,24 +45,6 @@ services:
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
       LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
       LANGCHAIN_PROJECT: "opea-embedding-service"
-    restart: unless-stopped
-  retriever:
-    image: opea/retriever-redis:latest
-    container_name: retriever-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "7000:7000"
-    ipc: host
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
-      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
-      LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
-      LANGCHAIN_PROJECT: "opea-retriever-service"
     restart: unless-stopped
   tei-reranking-service:
     image: ghcr.io/huggingface/text-embeddings-inference:1.2

--- a/ChatQnA/docker/xeon/docker_compose.yaml
+++ b/ChatQnA/docker/xeon/docker_compose.yaml
@@ -5,7 +5,7 @@
 version: "3.8"
 
 include:
- - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+ - ../data-service/${DATA_SERVICE:-redis}/docker-compose.yaml
 
 services:
   tei-embedding-service:

--- a/ChatQnA/docker/xeon/docker_compose.yaml
+++ b/ChatQnA/docker/xeon/docker_compose.yaml
@@ -4,28 +4,10 @@
 
 version: "3.8"
 
+include:
+ - ../data-service/${DATA_SERVICE}/docker-compose.yaml
+
 services:
-  redis-vector-db:
-    image: redis/redis-stack:7.2.0-v9
-    container_name: redis-vector-db
-    ports:
-      - "6379:6379"
-      - "8001:8001"
-  dataprep-redis-service:
-    image: opea/dataprep-redis:latest
-    container_name: dataprep-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "6007:6007"
-      - "6008:6008"
-      - "6009:6009"
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-embedding-server
@@ -55,25 +37,6 @@ services:
       LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
       LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
       LANGCHAIN_PROJECT: "opea-embedding-service"
-    restart: unless-stopped
-  retriever:
-    image: opea/retriever-redis:latest
-    container_name: retriever-redis-server
-    depends_on:
-      - redis-vector-db
-    ports:
-      - "7000:7000"
-    ipc: host
-    environment:
-      no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      REDIS_URL: ${REDIS_URL}
-      INDEX_NAME: ${INDEX_NAME}
-      TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
-      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
-      LANGCHAIN_TRACING_V2: ${LANGCHAIN_TRACING_V2}
-      LANGCHAIN_PROJECT: "opea-retriever-service"
     restart: unless-stopped
   tei-reranking-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2


### PR DESCRIPTION
## Description

To support the usage and implementation of other databases including redis, qdrant, and pgvector, I modified the compose files to use an include for the three microservices corresponding to data serving and retrieval (vector-db, retriever, and dataprep). 

## Issues

Tangentially related to #439 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds new functionality)

## Dependencies

N/A

## Tests

Ran [existing test](https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/tests/test_chatqna_on_xeon.sh) on xeon to verify that these changes didn't affect the existing redis implementation. Manually mutated the file to modify the DATA_SERVICE environment variable (as well as corresponding variables such as PG_CONNECTION_STRING) and verified that this works with pgvector and qdrant.