### PR TITLE
Fix a minor bug for chatqna in docker-compose (#442)

### DIFF
--- a/ChatQnA/docker/gpu/docker_compose.yaml
+++ b/ChatQnA/docker/gpu/docker_compose.yaml
@@ -27,7 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
   tei-embedding-service:
-    image: ghcr.io/huggingface/text-embeddings-inference:1.2
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-embedding-server
     ports:
       - "8090:80"
@@ -83,7 +83,7 @@ services:
       LANGCHAIN_PROJECT: "opea-retriever-service"
     restart: unless-stopped
   tei-reranking-service:
-    image: ghcr.io/huggingface/text-embeddings-inference:1.2
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-reranking-server
     ports:
       - "8808:80"


### PR DESCRIPTION
## Description

Embedding and reranking services failed to run on GPU H100. 
Change the image tag and use CPU for these services. This PR will fix #442

## Issues

#442

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

N/A
