### PR TITLE
doc: fix headings in markdown files

### DIFF
--- a/DocSum/docker/ui/react/README.md
+++ b/DocSum/docker/ui/react/README.md
@@ -1,12 +1,12 @@
-<h1 align="center" id="title">Doc Summary React</h1>
+# Doc Summary React
 
-### 📸 Project Screenshots
+## 📸 Project Screenshots
 
 ![project-screenshot](../../../assets/img/docsum-ui-react.png)
 ![project-screenshot](../../../assets/img/docsum-ui-react-file.png)
 ![project-screenshot](../../../assets/img/docsum-ui-react-error.png)
 
-<h2>🧐 Features</h2>
+## 🧐 Features
 
 Here're some of the project's features:
 
@@ -14,7 +14,7 @@ Here're some of the project's features:
 - Summarizing Text via Pasting: Paste the text to be summarized into the text box, then click 'Generate Summary' to produce a condensed summary of the content, which will be displayed in the 'Summary' box on the right.
 - Scroll to Bottom: The summarized content will automatically scroll to the bottom.
 
-<h2>🛠️ Get it Running:</h2>
+## 🛠️ Get it Running
 
 1. Clone the repo.
 

--- a/DocSum/docker/xeon/README.md
+++ b/DocSum/docker/xeon/README.md
@@ -150,10 +150,10 @@ export LANGCHAIN_API_KEY=ls_...
 Open this URL `http://{host_ip}:5173` in your browser to access the svelte based frontend.
 Open this URL `http://{host_ip}:5174` in your browser to access the React based frontend.
 
-#### Svelte UI
+### Svelte UI
 
 ![project-screenshot](../../assets/img/docSum_ui_text.png)
 
-#### React UI
+### React UI
 
 ![preject-react-screenshot](../../assets/img/docsum-ui-react.png)


### PR DESCRIPTION
First (and only) H1 heading is the title and subsequent headings should not skip levels (e.g., from H2 to H4).
