### PR TITLE
Fix missing TEI_ENDPOINT env var in chatqna compose config 

### DIFF
--- a/ChatQnA/docker/aipc/compose.yaml
+++ b/ChatQnA/docker/aipc/compose.yaml
@@ -23,6 +23,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
     container_name: tei-embedding-server

--- a/ChatQnA/docker/aipc/compose.yaml
+++ b/ChatQnA/docker/aipc/compose.yaml
@@ -24,6 +24,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
     container_name: tei-embedding-server

--- a/ChatQnA/docker/gaudi/README.md
+++ b/ChatQnA/docker/gaudi/README.md
@@ -69,19 +69,6 @@ Build microservice docker.
 docker build --no-cache -t opea/llm-vllm-ray:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/llms/text-generation/vllm-ray/docker/Dockerfile.microservice .
 ```
 
-#### 5.4 Use Ray Serve
-
-Build Ray Serve docker.
-
-```bash
-docker build --no-cache -t ray_serve:habana --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/llms/text-generation/ray_serve/docker/Dockerfile.rayserve .
-```
-
-Build microservice docker.
-
-```bash
-docker build --no-cache -t opea/llm-ray:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/llms/text-generation/ray_serve/docker/Dockerfile.microservice .
-```
 
 ### 6. Build Dataprep Image
 

--- a/ChatQnA/docker/gaudi/README.md
+++ b/ChatQnA/docker/gaudi/README.md
@@ -69,7 +69,6 @@ Build microservice docker.
 docker build --no-cache -t opea/llm-vllm-ray:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/llms/text-generation/vllm-ray/docker/Dockerfile.microservice .
 ```
 
-
 ### 6. Build Dataprep Image
 
 ```bash

--- a/ChatQnA/docker/gaudi/compose.yaml
+++ b/ChatQnA/docker/gaudi/compose.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gaudi/compose.yaml
+++ b/ChatQnA/docker/gaudi/compose.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gaudi/compose_guardrails.yaml
+++ b/ChatQnA/docker/gaudi/compose_guardrails.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tgi-guardrails-service:
     image: ghcr.io/huggingface/tgi-gaudi:2.0.1
     container_name: tgi-guardrails-server

--- a/ChatQnA/docker/gaudi/compose_guardrails.yaml
+++ b/ChatQnA/docker/gaudi/compose_guardrails.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tgi-guardrails-service:
     image: ghcr.io/huggingface/tgi-gaudi:2.0.1
     container_name: tgi-guardrails-server

--- a/ChatQnA/docker/gaudi/compose_ray_serve.yaml
+++ b/ChatQnA/docker/gaudi/compose_ray_serve.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gaudi/compose_ray_serve.yaml
+++ b/ChatQnA/docker/gaudi/compose_ray_serve.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gaudi/compose_vllm.yaml
+++ b/ChatQnA/docker/gaudi/compose_vllm.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gaudi/compose_vllm.yaml
+++ b/ChatQnA/docker/gaudi/compose_vllm.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gaudi/compose_vllm_ray.yaml
+++ b/ChatQnA/docker/gaudi/compose_vllm_ray.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gaudi/compose_vllm_ray.yaml
+++ b/ChatQnA/docker/gaudi/compose_vllm_ray.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: opea/tei-gaudi:latest
     container_name: tei-embedding-gaudi-server

--- a/ChatQnA/docker/gpu/compose.yaml
+++ b/ChatQnA/docker/gpu/compose.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
     container_name: tei-embedding-server

--- a/ChatQnA/docker/gpu/compose.yaml
+++ b/ChatQnA/docker/gpu/compose.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
     container_name: tei-embedding-server

--- a/ChatQnA/docker/xeon/compose.yaml
+++ b/ChatQnA/docker/xeon/compose.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
     container_name: tei-embedding-server

--- a/ChatQnA/docker/xeon/compose.yaml
+++ b/ChatQnA/docker/xeon/compose.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
     container_name: tei-embedding-server

--- a/ChatQnA/docker/xeon/docker_compose_qdrant.yaml
+++ b/ChatQnA/docker/xeon/docker_compose_qdrant.yaml
@@ -25,6 +25,7 @@ services:
       QDRANT: ${host_ip}
       QDRANT_PORT: 6333
       COLLECTION_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-embedding-server

--- a/ChatQnA/docker/xeon/docker_compose_qdrant.yaml
+++ b/ChatQnA/docker/xeon/docker_compose_qdrant.yaml
@@ -26,6 +26,8 @@ services:
       QDRANT_PORT: 6333
       COLLECTION_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-embedding-server

--- a/ChatQnA/docker/xeon/docker_compose_vllm.yaml
+++ b/ChatQnA/docker/xeon/docker_compose_vllm.yaml
@@ -26,6 +26,7 @@ services:
       https_proxy: ${https_proxy}
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
+      TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-embedding-server

--- a/ChatQnA/docker/xeon/docker_compose_vllm.yaml
+++ b/ChatQnA/docker/xeon/docker_compose_vllm.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
   tei-embedding-service:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.2
     container_name: tei-embedding-server


### PR DESCRIPTION
## Description

Fixed the issue in the Docker Compose configuration where the missing TEI_ENDPOINT environment variable caused the datapre component to actually use the local embedding model.
## Issues

n/a


## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


## Dependencies

n/a

## Tests

Describe the tests that you ran to verify your changes.
