### PR TITLE
Fix minor issue in ChatQnA Gaudi docker README

### DIFF
--- a/ChatQnA/docker/gaudi/README.md
+++ b/ChatQnA/docker/gaudi/README.md
@@ -306,7 +306,7 @@ curl http://${host_ip}:8008/generate \
 
 ```bash
 #vLLM Service
-curl http://${your_ip}:8008/v1/completions \
+curl http://${host_ip}:8008/v1/completions \
   -H "Content-Type: application/json" \
   -d '{
   "model": "${LLM_MODEL_ID}",
@@ -318,7 +318,7 @@ curl http://${your_ip}:8008/v1/completions \
 
 ```bash
 #vLLM-on-Ray Service
-curl http://${your_ip}:8008/v1/chat/completions \
+curl http://${host_ip}:8008/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "${LLM_MODEL_ID}", "messages": [{"role": "user", "content": "What is Deep Learning?"}]}'
 ```


### PR DESCRIPTION
## Description

This PR fixes a minor issue in the ChatQnA Gaudi docker README, where a couple of commands are using a `${your_ip}` env var when the rest of the README is using `${host_ip}`. Copy/pasting the commands cause an error without this fix.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

N/A
