### PR TITLE
Add dataprep microservice to chatQnA example and the e2e test

### DIFF
--- a/ChatQnA/kubernetes/chatQnA_dataprep_gaudi.yaml
+++ b/ChatQnA/kubernetes/chatQnA_dataprep_gaudi.yaml
@@ -1,0 +1,76 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: gmc.opea.io/v1alpha3
+kind: GMConnector
+metadata:
+  labels:
+    app.kubernetes.io/name: gmconnector
+    app.kubernetes.io/managed-by: kustomize
+    gmc/platform: gaudi
+  name: chatqa
+  namespace: chatqa
+spec:
+  routerConfig:
+    name: router
+    serviceName: router-service
+  nodes:
+    root:
+      routerType: Sequence
+      steps:
+      - name: Embedding
+        internalService:
+          serviceName: embedding-svc
+          config:
+            endpoint: /v1/embeddings
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-gaudi-svc
+      - name: TeiEmbeddingGaudi
+        internalService:
+          serviceName: tei-embedding-gaudi-svc
+          isDownstreamService: true
+      - name: Retriever
+        data: $response
+        internalService:
+          serviceName: retriever-svc
+          config:
+            endpoint: /v1/retrieval
+            REDIS_URL: redis-vector-db
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-gaudi-svc
+      - name: VectorDB
+        internalService:
+          serviceName: redis-vector-db
+          isDownstreamService: true
+      - name: Reranking
+        data: $response
+        internalService:
+          serviceName: reranking-svc
+          config:
+            endpoint: /v1/reranking
+            TEI_RERANKING_ENDPOINT: tei-reranking-svc
+      - name: TeiReranking
+        internalService:
+          serviceName: tei-reranking-svc
+          config:
+            endpoint: /rerank
+          isDownstreamService: true
+      - name: Llm
+        data: $response
+        internalService:
+          serviceName: llm-svc
+          config:
+            endpoint: /v1/chat/completions
+            TGI_LLM_ENDPOINT: tgi-gaudi-svc
+      - name: TgiGaudi
+        internalService:
+          serviceName: tgi-gaudi-svc
+          config:
+            endpoint: /generate
+          isDownstreamService: true
+      - name: DataPrep
+        internalService:
+          serviceName: data-prep-svc
+          config:
+            endpoint: /v1/dataprep
+            REDIS_URL: redis-vector-db
+            TEI_ENDPOINT: tei-embedding-gaudi-svc
+          isDownstreamService: true

--- a/ChatQnA/kubernetes/chatQnA_dataprep_xeon.yaml
+++ b/ChatQnA/kubernetes/chatQnA_dataprep_xeon.yaml
@@ -1,0 +1,76 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: gmc.opea.io/v1alpha3
+kind: GMConnector
+metadata:
+  labels:
+    app.kubernetes.io/name: gmconnector
+    app.kubernetes.io/managed-by: kustomize
+    gmc/platform: xeon
+  name: chatqa
+  namespace: chatqa
+spec:
+  routerConfig:
+    name: router
+    serviceName: router-service
+  nodes:
+    root:
+      routerType: Sequence
+      steps:
+      - name: Embedding
+        internalService:
+          serviceName: embedding-svc
+          config:
+            endpoint: /v1/embeddings
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-svc
+      - name: TeiEmbedding
+        internalService:
+          serviceName: tei-embedding-svc
+          isDownstreamService: true
+      - name: Retriever
+        data: $response
+        internalService:
+          serviceName: retriever-svc
+          config:
+            endpoint: /v1/retrieval
+            REDIS_URL: redis-vector-db
+            TEI_EMBEDDING_ENDPOINT: tei-embedding-svc
+      - name: VectorDB
+        internalService:
+          serviceName: redis-vector-db
+          isDownstreamService: true
+      - name: Reranking
+        data: $response
+        internalService:
+          serviceName: reranking-svc
+          config:
+            endpoint: /v1/reranking
+            TEI_RERANKING_ENDPOINT: tei-reranking-svc
+      - name: TeiReranking
+        internalService:
+          serviceName: tei-reranking-svc
+          config:
+            endpoint: /rerank
+          isDownstreamService: true
+      - name: Llm
+        data: $response
+        internalService:
+          serviceName: llm-svc
+          config:
+            endpoint: /v1/chat/completions
+            TGI_LLM_ENDPOINT: tgi-service-m
+      - name: Tgi
+        internalService:
+          serviceName: tgi-service-m
+          config:
+            endpoint: /generate
+          isDownstreamService: true
+      - name: DataPrep
+        internalService:
+          serviceName: data-prep-svc
+          config:
+            endpoint: /v1/dataprep
+            REDIS_URL: redis-vector-db
+            TEI_ENDPOINT: tei-embedding-svc
+          isDownstreamService: true

--- a/ChatQnA/tests/test_gmc_on_gaudi.sh
+++ b/ChatQnA/tests/test_gmc_on_gaudi.sh
@@ -7,11 +7,13 @@ USER_ID=$(whoami)
 LOG_PATH=/home/$(whoami)/logs
 MOUNT_DIR=/home/$USER_ID/.cache/huggingface/hub
 IMAGE_REPO=${IMAGE_REPO:-}
+CHATQNA_DATAPREP_NAMESPACE="${APP_NAMESPACE}-chatqna-dataprep"
 
 function install_chatqna() {
+   # Create namespace APP_NAMESPACE
    kubectl create ns $APP_NAMESPACE
-   sed -i "s|namespace: chatqa|namespace: $APP_NAMESPACE|g"  ./chatQnA_xeon.yaml
-   kubectl apply -f ./chatQnA_xeon.yaml
+   sed -i "s|namespace: chatqa|namespace: $APP_NAMESPACE|g"  ./chatQnA_gaudi.yaml
+   kubectl apply -f ./chatQnA_gaudi.yaml
 
    # Wait until the router service is ready
    echo "Waiting for the chatqa router service to be ready..."
@@ -23,6 +25,22 @@ function install_chatqna() {
    TGI_POD_NAME=$(kubectl get pods --namespace=$APP_NAMESPACE | grep ^tgi-service | awk '{print $1}')
    kubectl describe pod $TGI_POD_NAME -n $APP_NAMESPACE
    kubectl wait --for=condition=ready pod/$TGI_POD_NAME --namespace=$APP_NAMESPACE --timeout=300s
+
+   # Create namespace CHATQNA_DATAPREP_NAMESPACE
+   kubectl create ns $CHATQNA_DATAPREP_NAMESPACE
+   sed -i "s|namespace: chatqa|namespace: $CHATQNA_DATAPREP_NAMESPACE|g"  ./chatQnA_dataprep_gaudi.yaml
+   kubectl apply -f ./chatQnA_dataprep_gaudi.yaml
+
+   # Wait until the router service is ready
+   echo "Waiting for the chatqa-dataprep router service to be ready..."
+   wait_until_pod_ready "chatqa-dataprep router" $CHATQNA_DATAPREP_NAMESPACE "router-service"
+   output=$(kubectl get pods -n $CHATQNA_DATAPREP_NAMESPACE)
+   echo $output
+
+   # Wait until the tgi pod is ready
+   TGI_POD_NAME=$(kubectl get pods --namespace=$CHATQNA_DATAPREP_NAMESPACE | grep ^tgi-service | awk '{print $1}')
+   kubectl describe pod $TGI_POD_NAME -n $CHATQNA_DATAPREP_NAMESPACE
+   kubectl wait --for=condition=ready pod/$TGI_POD_NAME --namespace=$CHATQNA_DATAPREP_NAMESPACE --timeout=300s
 }
 
 function validate_chatqna() {
@@ -78,6 +96,86 @@ function validate_chatqna() {
    fi
 
    rm -f ./gmc.opea.io_gmconnectors.yaml ./gmc-manager-rbac.yaml ./gmc-manager.yaml manifests/gmc-router.yaml
+}
+
+function validate_chatqna_dataprep() {
+   # deploy client pod for testing
+   kubectl create deployment client-test -n $CHATQNA_DATAPREP_NAMESPACE --image=python:3.8.13 -- sleep infinity
+
+   # wait for client pod ready
+   wait_until_pod_ready "client-test" $CHATQNA_DATAPREP_NAMESPACE "client-test"
+   # giving time to populating data
+
+   max_retry=20
+   # make sure microservice retriever is ready
+   # try to curl retriever-svc for max_retry times
+   for ((i=1; i<=max_retry; i++))
+   do
+     curl http://retriever-svc.$CHATQNA_DATAPREP_NAMESPACE:7000/v1/retrieval -X POST \
+       -d '{"text":"What is the revenue of Nike in 2023?","embedding":"'"${your_embedding}"'"}' \
+       -H 'Content-Type: application/json' && break
+     sleep 10
+   done
+
+   # if i is bigger than max_retry, then exit with error
+   if [ $i -gt $max_retry ]; then
+       echo "Microservice failed, exit with error."
+       exit 1
+   fi
+
+   kubectl get pods -n $CHATQNA_DATAPREP_NAMESPACE
+   # send request to chatqnA
+   export CLIENT_POD=$(kubectl get pod -n $CHATQNA_DATAPREP_NAMESPACE -l app=client-test -o jsonpath={.items..metadata.name})
+   echo "$CLIENT_POD"
+   accessUrl=$(kubectl get gmc -n $CHATQNA_DATAPREP_NAMESPACE -o jsonpath="{.items[?(@.metadata.name=='chatqa')].status.accessUrl}")
+   kubectl exec "$CLIENT_POD" -n $CHATQNA_DATAPREP_NAMESPACE -- curl "$accessUrl/dataprep"  -X POST  -F 'link_list=["https://raw.githubusercontent.com/opea-project/GenAIInfra/main/microservices-connector/test/data/gaudi.txt"]' -H "Content-Type: multipart/form-data" > $LOG_PATH/curl_dataprep.log
+   exit_code=$?
+   if [ $exit_code -ne 0 ]; then
+       echo "chatqna failed, please check the logs in ${LOG_PATH}!"
+       exit 1
+   fi
+
+   echo "Checking response results, make sure the output is reasonable. "
+   local status=false
+   if [[ -f $LOG_PATH/curl_dataprep.log ]] && \
+   [[ $(grep -c "Data preparation succeeded" $LOG_PATH/curl_dataprep.log) != 0 ]]; then
+       status=true
+   fi
+   if [ $status == false ]; then
+       if [[ -f $LOG_PATH/curl_dataprep.log ]]; then
+           cat $LOG_PATH/curl_dataprep.log
+       fi
+       echo "Response check failed, please check the logs in artifacts!"
+       exit 1
+   else
+       echo "Response check succeed!"
+   fi
+
+   kubectl exec "$CLIENT_POD" -n $CHATQNA_DATAPREP_NAMESPACE -- curl $accessUrl  -X POST  -d '{"text":"What are the key features of Intel Gaudi?","parameters":{"max_new_tokens":17, "do_sample": true}}' -H 'Content-Type: application/json' > $LOG_PATH/curl_chatqna_dataprep.log
+   exit_code=$?
+   if [ $exit_code -ne 0 ]; then
+       echo "chatqna failed, please check the logs in ${LOG_PATH}!"
+       exit 1
+   fi
+
+   echo "Checking response results, make sure the output is reasonable. "
+   local status=false
+   if [[ -f $LOG_PATH/curl_chatqna_dataprep.log ]] && \
+   [[ $(grep -c "[DONE]" $LOG_PATH/curl_chatqna_dataprep.log) != 0 ]]; then
+       status=true
+   fi
+   if [ $status == false ]; then
+       if [[ -f $LOG_PATH/curl_chatqna_dataprep.log ]]; then
+           cat $LOG_PATH/curl_chatqna_dataprep.log
+       fi
+       echo "Response check failed, please check the logs in artifacts!"
+       exit 1
+   else
+       echo "Response check succeed!"
+   fi
+
+   rm -f ./gmc.opea.io_gmconnectors.yaml ./gmc-manager-rbac.yaml ./gmc-manager.yaml manifests/gmc-router.yaml
+   kubectl delete ns $CHATQNA_DATAPREP_NAMESPACE
 }
 
 function wait_until_pod_ready() {
@@ -140,6 +238,7 @@ case "$1" in
     validate_ChatQnA)
         pushd ChatQnA/kubernetes
         validate_chatqna
+        validate_chatqna_dataprep
         popd
         ;;
     *)

--- a/ChatQnA/tests/test_gmc_on_gaudi.sh
+++ b/ChatQnA/tests/test_gmc_on_gaudi.sh
@@ -50,23 +50,6 @@ function validate_chatqna() {
    # wait for client pod ready
    wait_until_pod_ready "client-test" $APP_NAMESPACE "client-test"
 
-   max_retry=20
-   # make sure microservice retriever is ready
-   # try to curl retriever-svc for max_retry times
-   for ((i=1; i<=max_retry; i++))
-   do
-     curl http://retriever-svc.$APP_NAMESPACE:7000/v1/retrieval -X POST \
-       -d '{"text":"What is the revenue of Nike in 2023?","embedding":"'"${your_embedding}"'"}' \
-       -H 'Content-Type: application/json' && break
-     sleep 10
-   done
-
-   # if i is bigger than max_retry, then exit with error
-   if [ $i -gt $max_retry ]; then
-       echo "Microservice failed, exit with error."
-       exit 1
-   fi
-
    kubectl get pods -n $APP_NAMESPACE
    # send request to chatqnA
    export CLIENT_POD=$(kubectl get pod -n $APP_NAMESPACE -l app=client-test -o jsonpath={.items..metadata.name})
@@ -105,23 +88,6 @@ function validate_chatqna_dataprep() {
    # wait for client pod ready
    wait_until_pod_ready "client-test" $CHATQNA_DATAPREP_NAMESPACE "client-test"
    # giving time to populating data
-
-   max_retry=20
-   # make sure microservice retriever is ready
-   # try to curl retriever-svc for max_retry times
-   for ((i=1; i<=max_retry; i++))
-   do
-     curl http://retriever-svc.$CHATQNA_DATAPREP_NAMESPACE:7000/v1/retrieval -X POST \
-       -d '{"text":"What is the revenue of Nike in 2023?","embedding":"'"${your_embedding}"'"}' \
-       -H 'Content-Type: application/json' && break
-     sleep 10
-   done
-
-   # if i is bigger than max_retry, then exit with error
-   if [ $i -gt $max_retry ]; then
-       echo "Microservice failed, exit with error."
-       exit 1
-   fi
 
    kubectl get pods -n $CHATQNA_DATAPREP_NAMESPACE
    # send request to chatqnA

--- a/ChatQnA/tests/test_gmc_on_gaudi.sh
+++ b/ChatQnA/tests/test_gmc_on_gaudi.sh
@@ -22,7 +22,7 @@ function install_chatqna() {
    echo $output
 
    # Wait until the tgi pod is ready
-   TGI_POD_NAME=$(kubectl get pods --namespace=$APP_NAMESPACE | grep ^tgi-service | awk '{print $1}')
+   TGI_POD_NAME=$(kubectl get pods --namespace=$APP_NAMESPACE | grep ^tgi-gaudi | awk '{print $1}')
    kubectl describe pod $TGI_POD_NAME -n $APP_NAMESPACE
    kubectl wait --for=condition=ready pod/$TGI_POD_NAME --namespace=$APP_NAMESPACE --timeout=300s
 
@@ -38,7 +38,7 @@ function install_chatqna() {
    echo $output
 
    # Wait until the tgi pod is ready
-   TGI_POD_NAME=$(kubectl get pods --namespace=$CHATQNA_DATAPREP_NAMESPACE | grep ^tgi-service | awk '{print $1}')
+   TGI_POD_NAME=$(kubectl get pods --namespace=$CHATQNA_DATAPREP_NAMESPACE | grep ^tgi-gaudi | awk '{print $1}')
    kubectl describe pod $TGI_POD_NAME -n $CHATQNA_DATAPREP_NAMESPACE
    kubectl wait --for=condition=ready pod/$TGI_POD_NAME --namespace=$CHATQNA_DATAPREP_NAMESPACE --timeout=300s
 }

--- a/ChatQnA/tests/test_gmc_on_xeon.sh
+++ b/ChatQnA/tests/test_gmc_on_xeon.sh
@@ -7,8 +7,10 @@ USER_ID=$(whoami)
 LOG_PATH=/home/$(whoami)/logs
 MOUNT_DIR=/home/$USER_ID/.cache/huggingface/hub
 IMAGE_REPO=${IMAGE_REPO:-}
+CHATQNA_DATAPREP_NAMESPACE="${APP_NAMESPACE}-chatqna-dataprep"
 
 function install_chatqna() {
+   # Create namespace APP_NAMESPACE
    kubectl create ns $APP_NAMESPACE
    sed -i "s|namespace: chatqa|namespace: $APP_NAMESPACE|g"  ./chatQnA_xeon.yaml
    kubectl apply -f ./chatQnA_xeon.yaml
@@ -23,6 +25,22 @@ function install_chatqna() {
    TGI_POD_NAME=$(kubectl get pods --namespace=$APP_NAMESPACE | grep ^tgi-service | awk '{print $1}')
    kubectl describe pod $TGI_POD_NAME -n $APP_NAMESPACE
    kubectl wait --for=condition=ready pod/$TGI_POD_NAME --namespace=$APP_NAMESPACE --timeout=300s
+
+   # Create namespace CHATQNA_DATAPREP_NAMESPACE
+   kubectl create ns $CHATQNA_DATAPREP_NAMESPACE
+   sed -i "s|namespace: chatqa|namespace: $CHATQNA_DATAPREP_NAMESPACE|g"  ./chatQnA_dataprep_xeon.yaml
+   kubectl apply -f ./chatQnA_dataprep_xeon.yaml
+
+   # Wait until the router service is ready
+   echo "Waiting for the chatqa-dataprep router service to be ready..."
+   wait_until_pod_ready "chatqa-dataprep router" $CHATQNA_DATAPREP_NAMESPACE "router-service"
+   output=$(kubectl get pods -n $CHATQNA_DATAPREP_NAMESPACE)
+   echo $output
+
+   # Wait until the tgi pod is ready
+   TGI_POD_NAME=$(kubectl get pods --namespace=$CHATQNA_DATAPREP_NAMESPACE | grep ^tgi-service | awk '{print $1}')
+   kubectl describe pod $TGI_POD_NAME -n $CHATQNA_DATAPREP_NAMESPACE
+   kubectl wait --for=condition=ready pod/$TGI_POD_NAME --namespace=$CHATQNA_DATAPREP_NAMESPACE --timeout=300s
 }
 
 function validate_chatqna() {
@@ -79,6 +97,87 @@ function validate_chatqna() {
    fi
 
    rm -f ./gmc.opea.io_gmconnectors.yaml ./gmc-manager-rbac.yaml ./gmc-manager.yaml manifests/gmc-router.yaml
+}
+
+
+function validate_chatqna_dataprep() {
+   # deploy client pod for testing
+   kubectl create deployment client-test -n $CHATQNA_DATAPREP_NAMESPACE --image=python:3.8.13 -- sleep infinity
+
+   # wait for client pod ready
+   wait_until_pod_ready "client-test" $CHATQNA_DATAPREP_NAMESPACE "client-test"
+   # giving time to populating data
+
+   max_retry=20
+   # make sure microservice retriever is ready
+   # try to curl retriever-svc for max_retry times
+   for ((i=1; i<=max_retry; i++))
+   do
+     curl http://retriever-svc.$CHATQNA_DATAPREP_NAMESPACE:7000/v1/retrieval -X POST \
+       -d '{"text":"What is the revenue of Nike in 2023?","embedding":"'"${your_embedding}"'"}' \
+       -H 'Content-Type: application/json' && break
+     sleep 10
+   done
+
+   # if i is bigger than max_retry, then exit with error
+   if [ $i -gt $max_retry ]; then
+       echo "Microservice failed, exit with error."
+       exit 1
+   fi
+
+   kubectl get pods -n $CHATQNA_DATAPREP_NAMESPACE
+   # send request to chatqnA
+   export CLIENT_POD=$(kubectl get pod -n $CHATQNA_DATAPREP_NAMESPACE -l app=client-test -o jsonpath={.items..metadata.name})
+   echo "$CLIENT_POD"
+   accessUrl=$(kubectl get gmc -n $CHATQNA_DATAPREP_NAMESPACE -o jsonpath="{.items[?(@.metadata.name=='chatqa')].status.accessUrl}")
+   kubectl exec "$CLIENT_POD" -n $CHATQNA_DATAPREP_NAMESPACE -- curl "$accessUrl/dataprep"  -X POST  -F 'link_list=["https://raw.githubusercontent.com/opea-project/GenAIInfra/main/microservices-connector/test/data/gaudi.txt"]' -H "Content-Type: multipart/form-data" > $LOG_PATH/curl_dataprep.log
+   exit_code=$?
+   if [ $exit_code -ne 0 ]; then
+       echo "chatqna failed, please check the logs in ${LOG_PATH}!"
+       exit 1
+   fi
+
+   echo "Checking response results, make sure the output is reasonable. "
+   local status=false
+   if [[ -f $LOG_PATH/curl_dataprep.log ]] && \
+   [[ $(grep -c "Data preparation succeeded" $LOG_PATH/curl_dataprep.log) != 0 ]]; then
+       status=true
+   fi
+   if [ $status == false ]; then
+       if [[ -f $LOG_PATH/curl_dataprep.log ]]; then
+           cat $LOG_PATH/curl_dataprep.log
+       fi
+       echo "Response check failed, please check the logs in artifacts!"
+       exit 1
+   else
+       echo "Response check succeed!"
+   fi
+
+   kubectl exec "$CLIENT_POD" -n $CHATQNA_DATAPREP_NAMESPACE -- curl $accessUrl  -X POST  -d '{"text":"What are the key features of Intel Gaudi?","parameters":{"max_new_tokens":17, "do_sample": true}}' -H 'Content-Type: application/json' > $LOG_PATH/curl_chatqna_dataprep.log
+   exit_code=$?
+   if [ $exit_code -ne 0 ]; then
+       echo "chatqna failed, please check the logs in ${LOG_PATH}!"
+       exit 1
+   fi
+
+   echo "Checking response results, make sure the output is reasonable. "
+   local status=false
+   if [[ -f $LOG_PATH/curl_chatqna_dataprep.log ]] && \
+   [[ $(grep -c "[DONE]" $LOG_PATH/curl_chatqna_dataprep.log) != 0 ]]; then
+       status=true
+   fi
+   if [ $status == false ]; then
+       if [[ -f $LOG_PATH/curl_chatqna_dataprep.log ]]; then
+           cat $LOG_PATH/curl_chatqna_dataprep.log
+       fi
+       echo "Response check failed, please check the logs in artifacts!"
+       exit 1
+   else
+       echo "Response check succeed!"
+   fi
+
+   rm -f ./gmc.opea.io_gmconnectors.yaml ./gmc-manager-rbac.yaml ./gmc-manager.yaml manifests/gmc-router.yaml
+   kubectl delete ns $CHATQNA_DATAPREP_NAMESPACE
 }
 
 function wait_until_pod_ready() {
@@ -141,6 +240,7 @@ case "$1" in
     validate_ChatQnA)
         pushd ChatQnA/kubernetes
         validate_chatqna
+        validate_chatqna_dataprep
         popd
         ;;
     *)

--- a/ChatQnA/tests/test_gmc_on_xeon.sh
+++ b/ChatQnA/tests/test_gmc_on_xeon.sh
@@ -51,23 +51,6 @@ function validate_chatqna() {
    wait_until_pod_ready "client-test" $APP_NAMESPACE "client-test"
    # giving time to populating data
 
-   max_retry=20
-   # make sure microservice retriever is ready
-   # try to curl retriever-svc for max_retry times
-   for ((i=1; i<=max_retry; i++))
-   do
-     curl http://retriever-svc.$APP_NAMESPACE:7000/v1/retrieval -X POST \
-       -d '{"text":"What is the revenue of Nike in 2023?","embedding":"'"${your_embedding}"'"}' \
-       -H 'Content-Type: application/json' && break
-     sleep 10
-   done
-
-   # if i is bigger than max_retry, then exit with error
-   if [ $i -gt $max_retry ]; then
-       echo "Microservice failed, exit with error."
-       exit 1
-   fi
-
    kubectl get pods -n $APP_NAMESPACE
    # send request to chatqnA
    export CLIENT_POD=$(kubectl get pod -n $APP_NAMESPACE -l app=client-test -o jsonpath={.items..metadata.name})
@@ -107,23 +90,6 @@ function validate_chatqna_dataprep() {
    # wait for client pod ready
    wait_until_pod_ready "client-test" $CHATQNA_DATAPREP_NAMESPACE "client-test"
    # giving time to populating data
-
-   max_retry=20
-   # make sure microservice retriever is ready
-   # try to curl retriever-svc for max_retry times
-   for ((i=1; i<=max_retry; i++))
-   do
-     curl http://retriever-svc.$CHATQNA_DATAPREP_NAMESPACE:7000/v1/retrieval -X POST \
-       -d '{"text":"What is the revenue of Nike in 2023?","embedding":"'"${your_embedding}"'"}' \
-       -H 'Content-Type: application/json' && break
-     sleep 10
-   done
-
-   # if i is bigger than max_retry, then exit with error
-   if [ $i -gt $max_retry ]; then
-       echo "Microservice failed, exit with error."
-       exit 1
-   fi
 
    kubectl get pods -n $CHATQNA_DATAPREP_NAMESPACE
    # send request to chatqnA


### PR DESCRIPTION
## Description

1. Add `dataprep` microservice to `chatQnA` example 
2. Add the e2e test for this example on both Xeon and Gaudi

## Issues

https://github.com/opea-project/GenAIInfra/issues/168
https://github.com/opea-project/GenAIInfra/issues/207

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

 `n/a`.

## Tests

This PR includes e2e test.
