### PR TITLE
Using habana docker 1.16.1 everywhere

### DIFF
--- a/VisualQnA/serving/Dockerfile
+++ b/VisualQnA/serving/Dockerfile
@@ -16,7 +16,7 @@
 
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.14.0/ubuntu22.04/habanalabs/pytorch-installer-2.1.1 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest AS hpu
 RUN rm -rf /etc/ssh/ssh_host*
 
 # Set environment variables


### PR DESCRIPTION
## Description

This PR proposes using `vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest` across the board.

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [N/A] Bug fix (non-breaking change which fixes an issue)
- [N/A] New feature (non-breaking change which adds new functionality)
- [N/A] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)

## Dependencies

None.

## Tests

This change won't affect CIs.