### PR TITLE
Update set_env.sh to add REDIS_HOST

### DIFF
--- a/ChatQnA/docker/xeon/set_env.sh
+++ b/ChatQnA/docker/xeon/set_env.sh
@@ -12,6 +12,7 @@ export TEI_RERANKING_ENDPOINT="http://${host_ip}:8808"
 export TGI_LLM_ENDPOINT="http://${host_ip}:9009"
 export REDIS_URL="redis://${host_ip}:6379"
 export INDEX_NAME="rag-redis"
+export REDIS_HOST=${host_ip}
 export MEGA_SERVICE_HOST_IP=${host_ip}
 export EMBEDDING_SERVICE_HOST_IP=${host_ip}
 export RETRIEVER_SERVICE_HOST_IP=${host_ip}


### PR DESCRIPTION
## Description

fix issue #591 
set_env.sh for ChantQnA on Xeon is missing the REDIS_HOST environment variable. because of that when do docker compose up -d, the retriever-redis-server container is showing errors. I solved the problem by adding export REDIS_HOST=${host_ip} Perhaps the same change in needed in other examples as well.

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

  [-] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
