### PR TITLE
change codegen tgi model

### DIFF
--- a/CodeGen/kubernetes/codegen_gaudi.yaml
+++ b/CodeGen/kubernetes/codegen_gaudi.yaml
@@ -29,6 +29,6 @@ spec:
         internalService:
           serviceName: tgi-gaudi-svc
           config:
-            MODEL_ID: ise-uiuc/Magicoder-S-DS-6.7B
+            MODEL_ID: meta-llama/CodeLlama-7b-hf
             endpoint: /generate
           isDownstreamService: true

--- a/CodeGen/kubernetes/codegen_xeon.yaml
+++ b/CodeGen/kubernetes/codegen_xeon.yaml
@@ -29,6 +29,6 @@ spec:
         internalService:
           serviceName: tgi-service
           config:
-            MODEL_ID: ise-uiuc/Magicoder-S-DS-6.7B
+            MODEL_ID: meta-llama/CodeLlama-7b-hf
             endpoint: /generate
           isDownstreamService: true

--- a/CodeGen/kubernetes/codegen_xeon.yaml
+++ b/CodeGen/kubernetes/codegen_xeon.yaml
@@ -29,5 +29,6 @@ spec:
         internalService:
           serviceName: tgi-service
           config:
+            MODEL_ID: HuggingFaceH4/mistral-7b-grok
             endpoint: /generate
           isDownstreamService: true

--- a/CodeGen/kubernetes/codegen_xeon.yaml
+++ b/CodeGen/kubernetes/codegen_xeon.yaml
@@ -29,6 +29,5 @@ spec:
         internalService:
           serviceName: tgi-service
           config:
-            MODEL_ID: meta-llama/CodeLlama-7b-hf
             endpoint: /generate
           isDownstreamService: true


### PR DESCRIPTION
## Description
Same as https://github.com/opea-project/GenAIExamples/issues/625 mentioned, the tgi 2.2.0 in v0.9 is also not compatible with "ise-uiuc/Magicoder-S-DS-6.7B" model, which GMC e2e is using in the codegen tests.

Update the model to "meta-llama/CodeLlama-7b-hf" in gaudi and "HuggingFaceH4/mistral-7b-grok" in xeon for codegen in GMC pipeline config

## Issues

 `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

 `n/a`.

## Tests

CI/CD will cover this
