### PR TITLE
minor fix mismatched hf token

### DIFF
--- a/AudioQnA/kubernetes/manifests/gaudi/audioqna.yaml
+++ b/AudioQnA/kubernetes/manifests/gaudi/audioqna.yaml
@@ -10,7 +10,7 @@ data:
   ASR_ENDPOINT: http://whisper-svc.default.svc.cluster.local:7066
   TTS_ENDPOINT: http://speecht5-svc.default.svc.cluster.local:7055
   LLM_MODEL_ID: Intel/neural-chat-7b-v3-3
-  HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+  HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   TGI_LLM_ENDPOINT: http://llm-dependency-svc.default.svc.cluster.local:3006
   MEGA_SERVICE_HOST_IP: audioqna-backend-server-svc
   ASR_SERVICE_HOST_IP: asr-svc

--- a/AudioQnA/kubernetes/manifests/xeon/audioqna.yaml
+++ b/AudioQnA/kubernetes/manifests/xeon/audioqna.yaml
@@ -10,7 +10,7 @@ data:
   ASR_ENDPOINT: http://whisper-svc.default.svc.cluster.local:7066
   TTS_ENDPOINT: http://speecht5-svc.default.svc.cluster.local:7055
   LLM_MODEL_ID: Intel/neural-chat-7b-v3-3
-  HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+  HUGGINGFACEHUB_API_TOKEN: "insert-your-huggingface-token-here"
   TGI_LLM_ENDPOINT: http://llm-dependency-svc.default.svc.cluster.local:3006
   MEGA_SERVICE_HOST_IP: audioqna-backend-server-svc
   ASR_SERVICE_HOST_IP: asr-svc


### PR DESCRIPTION
## Description

Fix wrong HF token pattern of `sed -i` following README for audioqna k8s manifest

```
sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" audioqna.yaml
```

## Issues

n/a
## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

na

## Tests

local test