### PR TITLE
Fix port conflict in llava-tgi-service in VisualQnA

### DIFF
--- a/VisualQnA/docker/xeon/compose.yaml
+++ b/VisualQnA/docker/xeon/compose.yaml
@@ -6,7 +6,7 @@ services:
     image: ghcr.io/huggingface/text-generation-inference:sha-e4201f4-intel-cpu
     container_name: tgi-llava-xeon-server
     ports:
-      - "9399:80"
+      - "8399:80"
     volumes:
       - "./data:/data"
     shm_size: 1g


### PR DESCRIPTION
## Description
- Changed the external port of llava-tgi-service from 9399 to 8399
- This change aligns the port with the configuration in VisualQnA/docker/gaudi/compose.yaml 
- Resolves the port conflict with the lvm-tgi service
- Internal port mapping remains unchanged (80)

## Issues
n/a

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)