### PR TITLE
[VisualQnA] Update compose.yaml to fix the endpoint url issue in UI

### DIFF
--- a/VisualQnA/docker/gaudi/compose.yaml
+++ b/VisualQnA/docker/gaudi/compose.yaml
@@ -65,7 +65,7 @@ services:
       - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
-      - CHAT_BASE_URL=${BACKEND_SERVICE_ENDPOINT}
+      - BACKEND_BASE_URL=${BACKEND_SERVICE_ENDPOINT}
     ipc: host
     restart: always
 

--- a/VisualQnA/docker/xeon/compose.yaml
+++ b/VisualQnA/docker/xeon/compose.yaml
@@ -60,7 +60,7 @@ services:
       - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
-      - CHAT_BASE_URL=${BACKEND_SERVICE_ENDPOINT}
+      - BACKEND_BASE_URL=${BACKEND_SERVICE_ENDPOINT}
     ipc: host
     restart: always
 


### PR DESCRIPTION
## Description

Update the environment variable name of the settings of `visualqna-gaudi-ui-server` in `compose.yaml` for both Xeon and Gaudi, from `CHAT_BASE_URL` to `BACKEND_BASE_URL`. 

Otherwise, the user's setting of `BACKEND_SERVICE_ENDPOINT` is invalid and won't be passed to the UI setting, instead using the default value `http://backend_address:8888/v1/visualqna` in [VisualQnA/docker/ui/svelte/.env](https://github.com/opea-project/GenAIExamples/blob/main/VisualQnA/docker/ui/svelte/.env#L1C21-L1C61), with the error below in the UI console.

![image](https://github.com/user-attachments/assets/1cc3c30b-d390-47a5-ad05-c3e66f6f65e3)

## Issues

Fix https://github.com/opea-project/GenAIExamples/issues/683

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

Test both [UI for Gaudi](https://github.com/opea-project/GenAIExamples/tree/main/VisualQnA/docker/gaudi#-launch-the-ui) and [UI for Xeon](https://github.com/opea-project/GenAIExamples/tree/main/VisualQnA/docker/xeon#-launch-the-ui)
