### PR TITLE
Provide the method to get nke-10k-2023.pdf

### DIFF
--- a/ChatQnA/docker/xeon/README.md
+++ b/ChatQnA/docker/xeon/README.md
@@ -381,11 +381,12 @@ docker compose -f compose_vllm.yaml up -d
 
    Update Knowledge Base via Local File [nke-10k-2023.pdf](https://github.com/opea-project/GenAIComps/blob/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf)
    Click [here](https://raw.githubusercontent.com/opea-project/GenAIComps/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf) to download the file via any web browser.
-   Or run this command to get the file on a terminal. 
+   Or run this command to get the file on a terminal.
+
    ```bash
    wget https://raw.githubusercontent.com/opea-project/GenAIComps/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf
    ```
-   
+
    Upload:
 
    ```bash

--- a/ChatQnA/docker/xeon/README.md
+++ b/ChatQnA/docker/xeon/README.md
@@ -379,7 +379,14 @@ docker compose -f compose_vllm.yaml up -d
 
    If you want to update the default knowledge base, you can use the following commands:
 
-   Update Knowledge Base via Local File [nke-10k-2023.pdf](https://github.com/opea-project/GenAIComps/blob/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf) Upload:
+   Update Knowledge Base via Local File [nke-10k-2023.pdf](https://github.com/opea-project/GenAIComps/blob/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf)
+   Click [here](https://raw.githubusercontent.com/opea-project/GenAIComps/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf) to download the file via any web browser.
+   Or run this command to get the file on a terminal. 
+   ```bash
+   wget https://raw.githubusercontent.com/opea-project/GenAIComps/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf
+   ```
+   
+   Upload:
 
    ```bash
    curl -X POST "http://${host_ip}:6007/v1/dataprep" \


### PR DESCRIPTION
Provide 2 methods, one is by web browser, another is on the a terminal.

## Description

When we get the nke-10k-2023.pdf from github directly,  the files is not the right one, and it will cause upload failed later by dataprep API.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

`n/a`.

## Tests

`wget https://raw.githubusercontent.com/opea-project/GenAIComps/main/comps/retrievers/langchain/redis/data/nke-10k-2023.pdf`
and then run:
```
curl -x "" -X POST "http://${host}:${port}/v1/dataprep" \
     -H "Content-Type: multipart/form-data" \
     -F "files=@./nke-10k-2023.pdf"
```
