### PR TITLE
Fix BACKEND_SERVICE_ENDPOINT variable value in the VideoQnA instructions

### DIFF
--- a/VideoQnA/docker_compose/intel/cpu/xeon/README.md
+++ b/VideoQnA/docker_compose/intel/cpu/xeon/README.md
@@ -144,7 +144,7 @@ export your_hf_api_token="Your_Huggingface_API_Token"
 **Append the value of the public IP address to the no_proxy list**
 
 ```
-export your_no_proxy=${your_no_proxy},"External_Public_IP"
+export your_no_proxy="${your_no_proxy},${host_ip}"
 ```
 
 Then you can run below commands or `source set_env.sh` to set all the variables
@@ -160,7 +160,7 @@ export RERANK_SERVICE_HOST_IP=${host_ip}
 export LVM_SERVICE_HOST_IP=${host_ip}
 
 export LVM_ENDPOINT="http://${host_ip}:9009"
-export BACKEND_SERVICE_ENDPOINT="http://${host_ip}:8888/v1/chatqna"
+export BACKEND_SERVICE_ENDPOINT="http://${host_ip}:8888/v1/videoqna"
 export BACKEND_HEALTH_CHECK_ENDPOINT="http://${host_ip}:8888/v1/health_check"
 export DATAPREP_SERVICE_ENDPOINT="http://${host_ip}:6007/v1/dataprep"
 export DATAPREP_GET_FILE_ENDPOINT="http://${host_ip}:6007/v1/dataprep/get_file"


### PR DESCRIPTION
## Description

This PR fixes an issue with the VideoQnA backend service endpoint environment variable in the docs where it incorrectly says chatqna instead of videoqna. Without this fix, I'm seeing the following error:

<img width="784" alt="image" src="https://github.com/user-attachments/assets/fdba2956-4212-4358-be5a-97a70ac129ed">

Also, I have a minor change to use `${host_ip}` when setting up the no_proxy env var, since that's `host_ip` is already defined earlier in the README.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Built all images and ran the VideoQnA microservices on a Xeon machine. I updated sample videos, brought up the UI, and submitted prompts.
