### PR TITLE
Fix: Update folder path to correct location

### DIFF
--- a/ChatQnA/kubernetes/intel/README.md
+++ b/ChatQnA/kubernetes/intel/README.md
@@ -13,7 +13,7 @@
 ## Deploy On Xeon
 
 ```
-cd GenAIExamples/ChatQnA/kubernetes/intel/cpu/xeon/manifests
+cd GenAIExamples/ChatQnA/kubernetes/intel/cpu/xeon/manifest
 export HUGGINGFACEHUB_API_TOKEN="YourOwnToken"
 sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" chatqna.yaml
 kubectl apply -f chatqna.yaml
@@ -33,7 +33,7 @@ kubectl apply -f chatqna_bf16.yaml
 ## Deploy On Gaudi
 
 ```
-cd GenAIExamples/ChatQnA/kubernetes/intel/hpu/gaudi/manifests
+cd GenAIExamples/ChatQnA/kubernetes/intel/hpu/gaudi/manifest
 export HUGGINGFACEHUB_API_TOKEN="YourOwnToken"
 sed -i "s/insert-your-huggingface-token-here/${HUGGINGFACEHUB_API_TOKEN}/g" chatqna.yaml
 kubectl apply -f chatqna.yaml


### PR DESCRIPTION
## Description

This pull request updates the deployment path for the ChatQnA service. The directory has been changed from:

```
GenAIExamples/ChatQnA/kubernetes/intel/cpu/xeon/manifests
GenAIExamples/ChatQnA/kubernetes/intel/hpu/gaudi/manifests
```

to:

```
GenAIExamples/ChatQnA/kubernetes/intel/cpu/xeon/manifest
GenAIExamples/ChatQnA/kubernetes/intel/hpu/gaudi/manifest
```


## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)
