### PR TITLE
instruction finetune README improvement

### DIFF
--- a/InstructionTuning/README.md
+++ b/InstructionTuning/README.md
@@ -1,6 +1,6 @@
 # Instruction Tuning
 
-Instruction tuning is the process of further training LLMs on a dataset consisting of (instruction, output) pairs in a supervised fashion, which bridges the gap between the next-word prediction objective of LLMs and the users' objective of having LLMs adhere to human instructions.
+Instruction tuning is the process of further training LLMs on a dataset consisting of (instruction, output) pairs in a supervised fashion, which bridges the gap between the next-word prediction objective of LLMs and the users' objective of having LLMs adhere to human instructions. This implementation deploys a Ray cluster for the task.
 
 ## Deploy Instruction Tuning Service
 
@@ -37,6 +37,8 @@ curl http://${your_ip}:8015/v1/fine_tuning/jobs \
     "model": "meta-llama/Llama-2-7b-chat-hf"
   }'
 ```
+
+The outputs of the finetune job (adapter_model.safetensors, adapter_config,json... ) are stored in `/home/user/comps/finetuning/output` and other execution logs are stored in `/home/user/ray_results`
 
 ### 3. Manage fine-tuning job
 


### PR DESCRIPTION
I was able to successfully run the instruction finetune on Gaudi 2 and I am just adding a few comments to the README for clarity.

I tested with a more recent Gaudi image than the one in [Dockerfile.intel_hpu](https://github.com/opea-project/GenAIComps/blob/main/comps/finetuning/Dockerfile.intel_hpu)
I used:
FROM vault.habana.ai/gaudi-docker/1.17.0/ubuntu22.04/habanalabs/pytorch-installer-2.3.1:latest as hpu
Instead of:
FROM opea/habanalabs:1.16.1-pytorch-installer-2.2.2 as hpu

This PR only has the readme additions but let me know if you want a PR to upgrade that as well. 
