### PR TITLE
Fix AIPC docker container network issue

### DIFF
--- a/ChatQnA/docker_compose/intel/cpu/aipc/compose.yaml
+++ b/ChatQnA/docker_compose/intel/cpu/aipc/compose.yaml
@@ -83,7 +83,6 @@ services:
     command: ["ollama serve & sleep 10 && ollama run ${OLLAMA_MODEL} & wait"]
     environment:
       no_proxy: ${no_proxy}
-      http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       OLLAMA_MODEL: ${OLLAMA_MODEL}
 


### PR DESCRIPTION
## Description

The summary of the proposed changes as long as the relevant motivation and context.

## Issues

AIPC Ollama Docker container failed to download LLM model because of http_proxy

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## Tests

#docker compose up -d
ollama automatically download set LLM model
