### PR TITLE
Use staged builds to minimize final image sizes

### DIFF
--- a/AudioQnA/Dockerfile
+++ b/AudioQnA/Dockerfile
@@ -1,31 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
-WORKDIR /home/user/GenAIComps
+WORKDIR $HOME
+
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./audioqna.py /home/user/audioqna.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./audioqna.py $HOME/audioqna.py
 
 ENTRYPOINT ["python", "audioqna.py"]

--- a/AudioQnA/Dockerfile.multilang
+++ b/AudioQnA/Dockerfile.multilang
@@ -1,32 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./audioqna_multilang.py /home/user/audioqna_multilang.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./audioqna_multilang.py $HOME/audioqna_multilang.py
 
 ENTRYPOINT ["python", "audioqna_multilang.py"]

--- a/AvatarChatbot/Dockerfile
+++ b/AvatarChatbot/Dockerfile
@@ -1,33 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
-WORKDIR /home/user/GenAIComps
+WORKDIR $HOME
 
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./avatarchatbot.py /home/user/avatarchatbot.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./avatarchatbot.py $HOME/avatarchatbot.py
 
 ENTRYPOINT ["python", "avatarchatbot.py"]

--- a/ChatQnA/Dockerfile
+++ b/ChatQnA/Dockerfile
@@ -1,35 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt && \
-    pip install --no-cache-dir langchain_core
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./chatqna.py /home/user/chatqna.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
 
-RUN echo 'ulimit -S -n 999999' >> ~/.bashrc
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./chatqna.py $HOME/chatqna.py
 
 ENTRYPOINT ["python", "chatqna.py"]

--- a/ChatQnA/Dockerfile.guardrails
+++ b/ChatQnA/Dockerfile.guardrails
@@ -1,35 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt && \
-    pip install --no-cache-dir langchain_core
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./chatqna.py /home/user/chatqna.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
 
-RUN echo 'ulimit -S -n 999999' >> ~/.bashrc
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./chatqna.py $HOME/chatqna.py
 
 ENTRYPOINT ["python", "chatqna.py", "--with-guardrails"]

--- a/ChatQnA/Dockerfile.without_rerank
+++ b/ChatQnA/Dockerfile.without_rerank
@@ -1,35 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    git \
-    libgl1-mesa-glx \
-    libjemalloc-dev
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt && \
-    pip install --no-cache-dir langchain_core
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./chatqna.py /home/user/chatqna.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
 
-RUN echo 'ulimit -S -n 999999' >> ~/.bashrc
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./chatqna.py $HOME/chatqna.py
 
 ENTRYPOINT ["python", "chatqna.py", "--without-rerank"]

--- a/ChatQnA/Dockerfile.wrapper
+++ b/ChatQnA/Dockerfile.wrapper
@@ -1,32 +1,49 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
 
-COPY ./chatqna_wrapper.py /home/user/chatqna.py
+# Stage 2: latest GenAIComps sources
+FROM base AS git
 
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
+RUN pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
+
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
 
-RUN echo 'ulimit -S -n 999999' >> ~/.bashrc
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./chatqna_wrapper.py $HOME/chatqna.py
 
 ENTRYPOINT ["python", "chatqna.py"]

--- a/CodeGen/Dockerfile
+++ b/CodeGen/Dockerfile
@@ -1,34 +1,51 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-ENV LANG=C.UTF-8
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./codegen.py /home/user/codegen.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+ENV LANG=C.UTF-8
+
+COPY ./codegen.py $HOME/codegen.py
 
 ENTRYPOINT ["python", "codegen.py"]

--- a/CodeTrans/Dockerfile
+++ b/CodeTrans/Dockerfile
@@ -1,32 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./code_translation.py /home/user/code_translation.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./code_translation.py $HOME/code_translation.py
 
 ENTRYPOINT ["python", "code_translation.py"]

--- a/DocIndexRetriever/Dockerfile
+++ b/DocIndexRetriever/Dockerfile
@@ -1,30 +1,49 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./retrieval_tool.py /home/user/retrieval_tool.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./retrieval_tool.py $HOME/retrieval_tool.py
 
 ENTRYPOINT ["python", "retrieval_tool.py"]

--- a/DocSum/Dockerfile
+++ b/DocSum/Dockerfile
@@ -1,32 +1,56 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git \
-    ffmpeg
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./docsum.py /home/user/docsum.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+USER root
+# FFmpeg needed for media processing
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+USER user
+
+COPY ./docsum.py $HOME/docsum.py
 
 ENTRYPOINT ["python", "docsum.py"]
-

--- a/EdgeCraftRAG/Dockerfile
+++ b/EdgeCraftRAG/Dockerfile
@@ -1,34 +1,49 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-COPY ./chatqna.py /home/user/chatqna.py
+WORKDIR $HOME
 
-WORKDIR /home/user
-RUN git clone https://github.com/opea-project/GenAIComps.git
 
-WORKDIR /home/user/GenAIComps
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
 
-RUN echo 'ulimit -S -n 999999' >> ~/.bashrc
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./chatqna.py $HOME/chatqna.py
 
 ENTRYPOINT ["python", "chatqna.py"]

--- a/EdgeCraftRAG/Dockerfile.server
+++ b/EdgeCraftRAG/Dockerfile.server
@@ -15,8 +15,7 @@ RUN wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
     gpg --yes --dearmor --output /usr/share/keyrings/intel-graphics.gpg
 RUN echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
     tee /etc/apt/sources.list.d/intel-gpu-jammy.list
-RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get update && apt-get install -y \
     intel-opencl-icd intel-level-zero-gpu level-zero intel-level-zero-gpu-raytracing \
     intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 \
     libegl-mesa0 libegl1-mesa libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \

--- a/FaqGen/Dockerfile
+++ b/FaqGen/Dockerfile
@@ -1,33 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./faqgen.py /home/user/faqgen.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./faqgen.py $HOME/faqgen.py
 
 ENTRYPOINT ["python", "faqgen.py"]

--- a/GraphRAG/Dockerfile
+++ b/GraphRAG/Dockerfile
@@ -1,33 +1,49 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    git \
-    libgl1-mesa-glx \
-    libjemalloc-dev
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
-RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt && \
-    pip install --no-cache-dir langchain_core
 
-COPY ./graphrag.py /home/user/graphrag.py
+# Stage 2: latest GenAIComps sources
+FROM base AS git
 
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
+RUN pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
+
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
 
-RUN echo 'ulimit -S -n 999999' >> ~/.bashrc
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./graphrag.py $HOME/graphrag.py
 
 ENTRYPOINT ["python", "graphrag.py"]

--- a/MultimodalQnA/Dockerfile
+++ b/MultimodalQnA/Dockerfile
@@ -1,31 +1,50 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./multimodalqna.py /home/user/multimodalqna.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./multimodalqna.py $HOME/multimodalqna.py
 
 ENTRYPOINT ["python", "multimodalqna.py"]
 # ENTRYPOINT ["/usr/bin/sleep", "infinity"]

--- a/SearchQnA/Dockerfile
+++ b/SearchQnA/Dockerfile
@@ -1,32 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./searchqna.py /home/user/searchqna.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./searchqna.py $HOME/searchqna.py
 
 ENTRYPOINT ["python", "searchqna.py"]

--- a/Translation/Dockerfile
+++ b/Translation/Dockerfile
@@ -1,42 +1,49 @@
-# Copyright (c) 2024 Intel Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
 
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-FROM python:3.11-slim
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./translation.py /home/user/translation.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./translation.py $HOME/translation.py
 
 ENTRYPOINT ["python", "translation.py"]

--- a/VideoQnA/Dockerfile
+++ b/VideoQnA/Dockerfile
@@ -1,33 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
+WORKDIR $HOME
 
-RUN git clone https://github.com/opea-project/GenAIComps.git
 
-WORKDIR /home/user/GenAIComps
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./videoqna.py /home/user/videoqna.py
-
-ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./videoqna.py $HOME/videoqna.py
 
 ENTRYPOINT ["python", "videoqna.py"]

--- a/VisualQnA/Dockerfile
+++ b/VisualQnA/Dockerfile
@@ -1,32 +1,49 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+# Stage 1: base setup used by other stages
+FROM python:3.11-slim AS base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/home/user
 
 RUN useradd -m -s /bin/bash user && \
-    mkdir -p /home/user && \
-    chown -R user /home/user/
+    mkdir -p $HOME && \
+    chown -R user $HOME
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
+WORKDIR $HOME
 
-WORKDIR /home/user/GenAIComps
+
+# Stage 2: latest GenAIComps sources
+FROM base AS git
+
+RUN apt-get update && apt-get install -y --no-install-recommends git
+RUN git clone --depth 1 https://github.com/opea-project/GenAIComps.git
+
+
+# Stage 3: common layer shared by services using GenAIComps
+FROM base AS comps-base
+
+# copy just relevant parts
+COPY --from=git $HOME/GenAIComps/comps $HOME/GenAIComps/comps
+COPY --from=git $HOME/GenAIComps/*.* $HOME/GenAIComps/LICENSE $HOME/GenAIComps/
+
+WORKDIR $HOME/GenAIComps
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt
+    pip install --no-cache-dir -r $HOME/GenAIComps/requirements.txt
+WORKDIR $HOME
 
-COPY ./visualqna.py /home/user/visualqna.py
-
-ENV PYTHONPATH=/home/user/GenAIComps
+ENV PYTHONPATH=$PYTHONPATH:$HOME/GenAIComps
 
 USER user
 
-WORKDIR /home/user
+
+# Stage 4: unique part
+FROM comps-base
+
+COPY ./visualqna.py $HOME/visualqna.py
 
 ENTRYPOINT ["python", "visualqna.py"]


### PR DESCRIPTION
## Description

Staged image builds so that final images do not have redundant things like:
- Git tool and its deps (e.g. Perl)
- Git repo history
- Test directories

And drop explicit installation of:
- `langchain_core`: _GenAIComps_ installs `langchain` which already depends on that
- `jemalloc` & GLX: nothing uses them (in any of the ChatQnA services), and for testing[1] it's trivial to create separate image adding those on top
- File descriptor limit increase for `~/.bashrc` (as these images run Python programs directly, not through Bash scripts)

=> This demonstrates that only 2-3 lines in the Dockerfiles are unique, and everything preceding those could be removed with a common base image.

[1] I assume those files were there to test this: https://pytorch.org/tutorials/recipes/recipes/tuning_guide.html#switch-memory-allocator

## Issues

Fixes: https://github.com/opea-project/GenAIExamples/issues/225

## Type of change

- [X] Others (image size improvement / Dockerfile cleanup)

## Dependencies

`n/a` (this removes redundant Git, Perl, jemalloc, GLX dependencies from final images)

## Tests

This is draft / example for fixing https://github.com/opea-project/GenAIExamples/issues/225

I have not tested it apart from verifying that images still build.

## Notes

In a proper fix, non-unique part of the Dockerfiles would be a separate base image, generated with GenAIComps repo Dockerfile, and Dockerfiles in this repository would depend on that image instead of `python-slim`.

However, that requires co-operation between these two repositories (unless components base image Dockerfile is also in this repo) and:
* CI handling this dependency i.e. building the base image first, when relevant
* That base image being in a repository accessible for building the application images
  * E.g. in OPEA Docker hub project

(I.e. it needs to be done by a member of this project, I cannot do it.)