### PR TITLE
update accuracy embedding endpoint for no wrapper

### DIFF
--- a/ChatQnA/benchmark/accuracy/eval_multihop.py
+++ b/ChatQnA/benchmark/accuracy/eval_multihop.py
@@ -43,10 +43,7 @@ class MultiHop_Evaluator(Evaluator):
     def get_retrieved_documents(self, query, arguments):
         data = {"inputs": query}
         headers = {"Content-Type": "application/json"}
-        response = requests.post(arguments.tei_embedding_endpoint + "/embed",
-            data=json.dumps(data),
-            headers=headers
-        )
+        response = requests.post(arguments.tei_embedding_endpoint + "/embed", data=json.dumps(data), headers=headers)
         if response.ok:
             embedding = response.json()[0]
         else:

--- a/ChatQnA/benchmark/accuracy/eval_multihop.py
+++ b/ChatQnA/benchmark/accuracy/eval_multihop.py
@@ -41,11 +41,14 @@ class MultiHop_Evaluator(Evaluator):
             return []
 
     def get_retrieved_documents(self, query, arguments):
-        data = {"text": query}
+        data = {"inputs": query}
         headers = {"Content-Type": "application/json"}
-        response = requests.post(arguments.embedding_endpoint, data=json.dumps(data), headers=headers)
+        response = requests.post(arguments.tei_embedding_endpoint + "/embed",
+            data=json.dumps(data),
+            headers=headers
+        )
         if response.ok:
-            embedding = response.json()["embedding"]
+            embedding = response.json()[0]
         else:
             print(f"Request for embedding failed due to {response.text}.")
             return []


### PR DESCRIPTION
## Description

for no wrapper ChatQnA service, there is no wrapper `embedding_endpoint`, so replace it with `tei_embedding_endpoint`.