### PR TITLE
Use docker stop instead of docker compose stop to avoid container clean up issue

### DIFF
--- a/.github/workflows/_run-docker-compose.yml
+++ b/.github/workflows/_run-docker-compose.yml
@@ -141,7 +141,11 @@ jobs:
           flag=${flag#test_}
           yaml_file=$(find . -type f -wholename "*${{ inputs.hardware }}/${flag}.yaml")
           echo $yaml_file
-          docker compose -f $yaml_file stop && docker compose -f $yaml_file rm -f || true
+          container_list=$(cat $yaml_file | grep container_name | cut -d':' -f2)
+          for container_name in $container_list; do
+              cid=$(docker ps -aq --filter "name=$container_name")
+              if [[ ! -z "$cid" ]]; then docker stop $cid && docker rm $cid && sleep 1s; fi
+          done 
           docker system prune -f
           docker rmi $(docker images --filter reference="*:5000/*/*" -q) || true
 

--- a/.github/workflows/_run-docker-compose.yml
+++ b/.github/workflows/_run-docker-compose.yml
@@ -145,7 +145,7 @@ jobs:
           for container_name in $container_list; do
               cid=$(docker ps -aq --filter "name=$container_name")
               if [[ ! -z "$cid" ]]; then docker stop $cid && docker rm $cid && sleep 1s; fi
-          done 
+          done
           docker system prune -f
           docker rmi $(docker images --filter reference="*:5000/*/*" -q) || true
 


### PR DESCRIPTION
## Description

Use docker stop instead of docker compose stop to avoid container clean up issue

## Issues

`no port specified: :<empty>` will cause the container clean up issue, which lead to port allocate issue for the next test. 
https://github.com/opea-project/GenAIExamples/actions/runs/11657629022/job/32477125804?pr=999#step:5:62 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
