### PR TITLE
Enable milvus version of ChatQnA

### DIFF
--- a/ChatQnA/docker_compose/intel/cpu/xeon/README_milvus.md
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/README_milvus.md
@@ -1,0 +1,101 @@
+# Build Mega Service of ChatQnA on Xeon
+
+Quick Start:
+
+1. Set up the environment variables.
+2. Run Docker Compose.
+3. Consume the ChatQnA Service.
+
+## Quick Start: 1.Setup Environment Variable
+
+```bash
+mkdir ~/OPEA -p
+mkdir ~/OPEA/tmp -p
+cd ~/OPEA
+git clone https://github.com/opea-project/GenAIExamples.git
+# If you want to build code, download GenAIComps
+git clone https://github.com/opea-project/GenAIComps.git
+```
+
+To set up environment variables for deploying ChatQnA services, follow these steps:
+
+1. Set the required environment variables:
+
+   ```bash
+   # Example: host_ip="192.168.1.1"
+   export host_ip="External_Public_IP"
+   export HUGGINGFACEHUB_API_TOKEN="Your_Huggingface_API_Token"
+   ```
+
+2. If you are in a proxy environment, also set the proxy-related environment variables:
+
+   ```bash
+   export http_proxy="Your_HTTP_Proxy"
+   export https_proxy="Your_HTTPs_Proxy"
+   # Example: no_proxy="localhost, 127.0.0.1, 192.168.1.1"
+   # Example: no_proxy="localhost, 127.0.0.1, 192.168.1.1"
+   ```
+
+3. Set up other environment variables:
+   ```bash
+   export host_ip="External_Public_IP"
+   export HUGGINGFACEHUB_API_TOKEN="Your_Huggingface_API_Token"
+   source ./set_env_milvus.sh
+   ```
+
+## Quick Start: 2.Run Docker Compose
+
+```bash
+cd ~/OPEA/GenAIExample/ChatQnA/docker_compose/intel/cpu/xeon
+docker compose -f ./compose_milvus.yaml up -d
+```
+
+It will automatically download the docker images on `docker hub`.
+
+
+In following cases, you could build docker image from source by yourself.
+
+- Failed to download the docker image.
+
+- If you want to use a specific version of Docker image.
+
+Please refer to 'Build Docker Images' in below.
+
+
+## QuickStart: 3.Consume the ChatQnA Service
+
+```bash
+curl http://${host_ip}:8888/v1/chatqna \
+    -H "Content-Type: application/json" \
+    -d '{
+        "messages": "What is the revenue of Nike in 2023?"
+    }'
+```
+
+## 🚀 Build Docker Images
+
+First of all, you need to build Docker Images locally and install the python package of it.
+
+```bash
+cd ~/OPEA/GenAIExample/ChatQnA/docker_compose/intel/cpu/xeon
+docker compose -f ./compose_milvus.yaml build
+```
+
+Then run the command `docker images`, you will have the following 5 Docker Images:
+
+1. `opea/dataprep-milvus:latest`
+2. `opea/retriever-milvus:latest`
+3. `opea/chatqna:latest`
+4. `opea/chatqna-ui:latest`
+5. `opea/nginx:latest`
+
+## 🚀 Start Microservices
+
+```
+cd ~/OPEA/GenAIExample/ChatQnA/docker_compose/intel/cpu/xeon
+docker compose -f up -d
+```
+
+### Valid the Microservices and Launch the UI
+
+To valid the Microservices, change models as well as Launch the UI, Pleser refer to ./README.md

--- a/ChatQnA/docker_compose/intel/cpu/xeon/README_milvus.md
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/README_milvus.md
@@ -52,7 +52,6 @@ docker compose -f ./compose_milvus.yaml up -d
 
 It will automatically download the docker images on `docker hub`.
 
-
 In following cases, you could build docker image from source by yourself.
 
 - Failed to download the docker image.
@@ -60,7 +59,6 @@ In following cases, you could build docker image from source by yourself.
 - If you want to use a specific version of Docker image.
 
 Please refer to 'Build Docker Images' in below.
-
 
 ## QuickStart: 3.Consume the ChatQnA Service
 

--- a/ChatQnA/docker_compose/intel/cpu/xeon/compose_milvus.yaml
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/compose_milvus.yaml
@@ -1,0 +1,241 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+  etcd:
+    container_name: milvus-etcd
+    image: quay.io/coreos/etcd:v3.5.5
+    environment:
+      - ETCD_AUTO_COMPACTION_MODE=revision
+      - ETCD_AUTO_COMPACTION_RETENTION=1000
+      - ETCD_QUOTA_BACKEND_BYTES=4294967296
+      - ETCD_SNAPSHOT_COUNT=50000
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  minio:
+    container_name: milvus-minio
+    image: minio/minio:RELEASE.2023-03-20T20-16-18Z
+    environment:
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+    ports:
+      - "5044:9001"
+      - "5043:9000"
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
+    command: minio server /minio_data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  milvus-standalone:
+    container_name: milvus-standalone
+    image: milvusdb/milvus:v2.4.9
+    command: ["milvus", "run", "standalone"]
+    security_opt:
+      - seccomp:unconfined
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    volumes:
+      - ./milvus.yaml:/milvus/configs/milvus.yaml
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      interval: 30s
+      start_period: 90s
+      timeout: 20s
+      retries: 3
+    ports:
+      - "19530:19530"
+      - "9091:9091"
+    depends_on:
+      - "etcd"
+      - "minio"
+
+  dataprep-milvus-service:
+    image: ${REGISTRY:-opea}/dataprep-milvus:${TAG:-latest}
+    build:
+      context: ../../../../../../fork-GenAIComps/
+      dockerfile: ./comps/dataprep/milvus/langchain/Dockerfile
+      args:
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+    container_name: dataprep-milvus-server
+    ports:
+      - "6007:6007"
+    depends_on:
+      - milvus-standalone
+      - tei-embedding-service
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      MILVUS_HOST: ${MILVUS_HOST}
+      MILVUS_PORT: ${MILVUS_PORT}
+      TEI_EMBEDDING_ENDPOINT: http://tei-embedding-service:80
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+
+  tei-embedding-service:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
+    container_name: tei-embedding-server
+    ports:
+      - "6006:80"
+    volumes:
+      - "./data:/data"
+    shm_size: 1g
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+    command: --model-id ${EMBEDDING_MODEL_ID} --auto-truncate
+
+  retriever-service:
+    image: opea/retriever-milvus:latest
+    build:
+      context: ../../../../../../fork-GenAIComps/
+      dockerfile: ./comps/retrievers/milvus/langchain/Dockerfile
+      args:
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+    container_name: retriever-milvus-server
+    depends_on:
+      - tei-embedding-service
+      - milvus-standalone
+    ports:
+      - "7000:7000"
+    ipc: host
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      MILVUS_HOST: ${MILVUS_HOST}
+      MILVUS_PORT: ${MILVUS_PORT}
+      TEI_EMBEDDING_ENDPOINT: http://tei-embedding-service:80
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+    restart: unless-stopped
+  tei-reranking-service:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
+    container_name: tei-reranking-server
+    ports:
+      - "8808:80"
+    volumes:
+      - "./data:/data"
+    shm_size: 1g
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+      HF_HUB_DISABLE_PROGRESS_BARS: 1
+      HF_HUB_ENABLE_HF_TRANSFER: 0
+    command: --model-id ${RERANK_MODEL_ID} --auto-truncate
+  tgi-service:
+    image: ghcr.io/huggingface/text-generation-inference:sha-e4201f4-intel-cpu
+    container_name: tgi-service
+    ports:
+      - "9009:80"
+    volumes:
+      - "./data:/data"
+    shm_size: 1g
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      HF_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+      HF_HUB_DISABLE_PROGRESS_BARS: 1
+      HF_HUB_ENABLE_HF_TRANSFER: 0
+    command: --model-id ${LLM_MODEL_ID} --cuda-graphs 0
+  chatqna-xeon-backend-server:
+    image: ${REGISTRY:-opea}/chatqna:${TAG:-latest}
+    build:
+      context: ../../../../
+      dockerfile: Dockerfile
+      args:
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+    container_name: chatqna-xeon-backend-server
+    depends_on:
+      - milvus-standalone
+      - tei-embedding-service
+      - dataprep-milvus-service
+      - retriever-service
+      - tei-reranking-service
+      - tgi-service
+    ports:
+      - "8888:8888"
+    environment:
+      - no_proxy=${no_proxy}
+      - https_proxy=${https_proxy}
+      - http_proxy=${http_proxy}
+      - MEGA_SERVICE_HOST_IP=chatqna-xeon-backend-server
+      - EMBEDDING_SERVER_HOST_IP=tei-embedding-service
+      - EMBEDDING_SERVER_PORT=${EMBEDDING_SERVER_PORT:-80}
+      - RETRIEVER_SERVICE_HOST_IP=retriever-service
+      - RERANK_SERVER_HOST_IP=tei-reranking-service
+      - RERANK_SERVER_PORT=${RERANK_SERVER_PORT:-80}
+      - LLM_SERVER_HOST_IP=tgi-service
+      - LLM_SERVER_PORT=${LLM_SERVER_PORT:-80}
+      - LLM_MODEL=${LLM_MODEL_ID}
+      - LOGFLAG=${LOGFLAG}
+    ipc: host
+    restart: always
+  chatqna-xeon-ui-server:
+    image: ${REGISTRY:-opea}/chatqna-ui:${TAG:-latest}
+    build:
+      context: ../../../../ui
+      dockerfile: docker/Dockerfile
+      args:
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+    container_name: chatqna-xeon-ui-server
+    depends_on:
+      - chatqna-xeon-backend-server
+    ports:
+      - "5173:5173"
+    environment:
+      - no_proxy=${no_proxy}
+      - https_proxy=${https_proxy}
+      - http_proxy=${http_proxy}
+    ipc: host
+    restart: always
+  chatqna-xeon-nginx-server:
+    image: ${REGISTRY:-opea}/nginx:${TAG:-latest}
+    build:
+      context: ../../../../../../GenAIComps/
+      dockerfile: comps/nginx/Dockerfile
+      args:
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+    container_name: chatqna-xeon-nginx-server
+    depends_on:
+      - chatqna-xeon-backend-server
+      - chatqna-xeon-ui-server
+    ports:
+      - "${NGINX_PORT:-80}:80"
+    environment:
+      - no_proxy=${no_proxy}
+      - https_proxy=${https_proxy}
+      - http_proxy=${http_proxy}
+      - FRONTEND_SERVICE_IP=chatqna-xeon-ui-server
+      - FRONTEND_SERVICE_PORT=5173
+      - BACKEND_SERVICE_NAME=chatqna
+      - BACKEND_SERVICE_IP=chatqna-xeon-backend-server
+      - BACKEND_SERVICE_PORT=8888
+      - DATAPREP_SERVICE_IP=dataprep-milvus-service
+      - DATAPREP_SERVICE_PORT=6007
+    ipc: host
+    restart: always
+
+networks:
+  default:
+    driver: bridge

--- a/ChatQnA/docker_compose/intel/cpu/xeon/set_env_milvus.sh
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/set_env_milvus.sh
@@ -1,3 +1,6 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
 export host_ip=$(hostname -i)
 export DOCKER_VOLUME_DIRECTORY="~/OPEA/tmp"
 export http_proxy=${http_proxy}
@@ -8,4 +11,3 @@ export MILVUS_PORT=19530
 export EMBEDDING_MODEL_ID="BAAI/bge-base-en-v1.5"
 export RERANK_MODEL_ID="BAAI/bge-reranker-base"
 export LLM_MODEL_ID="Intel/neural-chat-7b-v3-3"
-

--- a/ChatQnA/docker_compose/intel/cpu/xeon/set_env_milvus.sh
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/set_env_milvus.sh
@@ -1,0 +1,11 @@
+export host_ip=$(hostname -i)
+export DOCKER_VOLUME_DIRECTORY="~/OPEA/tmp"
+export http_proxy=${http_proxy}
+export https_proxy=${http_proxy}
+export no_proxy=${no_proxy},chatqna-xeon-ui-server,chatqna-xeon-backend-server,tei-embedding-service,tei-reranking-service,tgi-service,vllm_service,retriever-service,dataprep-milvus-service
+export MILVUS_HOST=${host_ip}
+export MILVUS_PORT=19530
+export EMBEDDING_MODEL_ID="BAAI/bge-base-en-v1.5"
+export RERANK_MODEL_ID="BAAI/bge-reranker-base"
+export LLM_MODEL_ID="Intel/neural-chat-7b-v3-3"
+


### PR DESCRIPTION
## Description

Enable milvus version of ChatQnA

## Issues

https://github.com/opea-project/GenAIExamples/issues/886

## Type of change

- [ ] New feature (non-breaking change which adds new functionality)


## Dependencies

No newly introduced 3rd party dependency.

Milvus is in GenAIComps already, but not enabled.

## Tests

Verify ChatQnA milvus with UI and RAG functionality.
