### PR TITLE
Fix ChatQnA ROCm compose Readme file and absolute path path for ROCM CI test

### DIFF
--- a/ChatQnA/docker_compose/amd/gpu/rocm/README.md
+++ b/ChatQnA/docker_compose/amd/gpu/rocm/README.md
@@ -1,4 +1,4 @@
-# Build and deploy CodeGen Application on AMD GPU (ROCm)
+# Build and deploy ChatQnA Application on AMD GPU (ROCm)
 
 ## Build MegaService of ChatQnA on AMD ROCm GPU
 

--- a/ChatQnA/tests/test_compose_on_rocm.sh
+++ b/ChatQnA/tests/test_compose_on_rocm.sh
@@ -45,7 +45,7 @@ export CHATQNA_RERANK_SERVICE_HOST_IP=${HOST_IP}
 export CHATQNA_LLM_SERVICE_HOST_IP=${HOST_IP}
 export CHATQNA_NGINX_PORT=80
 export CHATQNA_HUGGINGFACEHUB_API_TOKEN=${HUGGINGFACEHUB_API_TOKEN}
-export PATH="/home/huggingface/miniconda3/bin:$PATH"
+export PATH="~/miniconda3/bin:$PATH"
 
 function build_docker_images() {
     cd "$WORKPATH"/docker_image_build


### PR DESCRIPTION
## Type of change

- Fixed wrong app name in description for ROCm Readme file.
- Changed absolute path for conda bin location to home folder (~/)


