### PR TITLE
Fix code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/EdgeCraftRAG/Dockerfile.server
+++ b/EdgeCraftRAG/Dockerfile.server
@@ -23,6 +23,11 @@ RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/ 
 
+RUN mkdir /templates && \
+    chown -R user /templates
+COPY ./edgecraftrag/prompt_template/default_prompt.txt /templates/
+RUN chown -R user /templates/default_prompt.txt
+
 COPY ./edgecraftrag /home/user/edgecraftrag
 
 RUN mkdir -p /home/user/gradio_cache 

--- a/EdgeCraftRAG/docker_compose/intel/gpu/arc/compose.yaml
+++ b/EdgeCraftRAG/docker_compose/intel/gpu/arc/compose.yaml
@@ -16,6 +16,7 @@ services:
       - ${DOC_PATH:-${PWD}}:/home/user/docs
       - ${GRADIO_PATH:-${PWD}}:/home/user/gradio_cache
       - ${HF_CACHE:-${HOME}/.cache}:/home/user/.cache
+      - ${PROMPT_PATH:-${PWD}}:/templates/custom
     ports:
       - ${PIPELINE_SERVICE_PORT:-16010}:${PIPELINE_SERVICE_PORT:-16010}
     devices:

--- a/EdgeCraftRAG/docker_compose/intel/gpu/arc/compose_vllm.yaml
+++ b/EdgeCraftRAG/docker_compose/intel/gpu/arc/compose_vllm.yaml
@@ -16,6 +16,7 @@ services:
       - ${DOC_PATH:-${PWD}}:/home/user/docs
       - ${GRADIO_PATH:-${PWD}}:/home/user/gradio_cache
       - ${HF_CACHE:-${HOME}/.cache}:/home/user/.cache
+      - ${PROMPT_PATH:-${PWD}}:/templates/custom
     ports:
       - ${PIPELINE_SERVICE_PORT:-16010}:${PIPELINE_SERVICE_PORT:-16010}
     devices:

--- a/EdgeCraftRAG/edgecraftrag/components/generator.py
+++ b/EdgeCraftRAG/edgecraftrag/components/generator.py
@@ -26,15 +26,13 @@ class QnAGenerator(BaseComponent):
             ("\n\n", "\n"),
             ("\t\n", "\n"),
         )
-        safe_root = "/path/to/safe/templates"
+        safe_root = "/templates"
         template = os.path.normpath(os.path.join(safe_root, prompt_template))
         if not template.startswith(safe_root):
             raise ValueError("Invalid template path")
-        self.prompt = (
-            DocumentedContextRagPromptTemplate.from_file(template)
-            if os.path.isfile(template)
-            else DocumentedContextRagPromptTemplate.from_template(template)
-        )
+        if not os.path.exists(template):
+            raise ValueError("Template file not exists")
+        self.prompt = DocumentedContextRagPromptTemplate.from_file(template)
         self.llm = llm_model
         if isinstance(llm_model, str):
             self.model_id = llm_model

--- a/EdgeCraftRAG/edgecraftrag/components/generator.py
+++ b/EdgeCraftRAG/edgecraftrag/components/generator.py
@@ -26,7 +26,10 @@ class QnAGenerator(BaseComponent):
             ("\n\n", "\n"),
             ("\t\n", "\n"),
         )
-        template = prompt_template
+        safe_root = "/path/to/safe/templates"
+        template = os.path.normpath(os.path.join(safe_root, prompt_template))
+        if not template.startswith(safe_root):
+            raise ValueError("Invalid template path")
         self.prompt = (
             DocumentedContextRagPromptTemplate.from_file(template)
             if os.path.isfile(template)

--- a/EdgeCraftRAG/tests/configs/test_pipeline_local_llm.json
+++ b/EdgeCraftRAG/tests/configs/test_pipeline_local_llm.json
@@ -37,7 +37,7 @@
       "device": "auto",
       "weight": "INT4"
     },
-    "prompt_path": "./edgecraftrag/prompt_template/default_prompt.txt",
+    "prompt_path": "./default_prompt.txt",
     "inference_type": "local"
   },
   "active": "True"

--- a/EdgeCraftRAG/tests/configs/test_pipeline_vllm.json
+++ b/EdgeCraftRAG/tests/configs/test_pipeline_vllm.json
@@ -37,7 +37,7 @@
       "device": "auto",
       "weight": "INT4"
     },
-    "prompt_path": "./edgecraftrag/prompt_template/default_prompt.txt",
+    "prompt_path": "./default_prompt.txt",
     "inference_type": "vllm"
   },
   "active": "True"

--- a/EdgeCraftRAG/tests/test_compose_vllm_on_arc.sh
+++ b/EdgeCraftRAG/tests/test_compose_vllm_on_arc.sh
@@ -31,8 +31,7 @@ vLLM_ENDPOINT="http://${HOST_IP}:${VLLM_SERVICE_PORT}"
 function build_docker_images() {
     cd $WORKPATH/docker_image_build
     echo "Build all the images with --no-cache, check docker_image_build.log for details..."
-    service_list="server ui ecrag"
-    docker compose -f build.yaml build ${service_list} --no-cache > ${LOG_PATH}/docker_image_build.log
+    docker compose -f build.yaml build --no-cache > ${LOG_PATH}/docker_image_build.log
 
     echo "Build vllm_openvino image from GenAIComps..."
     cd $WORKPATH && git clone https://github.com/opea-project/GenAIComps.git && cd GenAIComps && git checkout "${opea_branch:-"main"}"

--- a/EdgeCraftRAG/tests/test_pipeline_local_llm.json
+++ b/EdgeCraftRAG/tests/test_pipeline_local_llm.json
@@ -37,7 +37,7 @@
       "device": "auto",
       "weight": "INT4"
     },
-    "prompt_path": "./edgecraftrag/prompt_template/default_prompt.txt",
+    "prompt_path": "./default_prompt.txt",
     "inference_type": "local"
   },
   "active": "True"

--- a/EdgeCraftRAG/ui/gradio/default.yaml
+++ b/EdgeCraftRAG/ui/gradio/default.yaml
@@ -29,7 +29,7 @@ postprocessor: "reranker"
 
 # Generator
 generator: "chatqna"
-prompt_path: "./edgecraftrag/prompt_template/default_prompt.txt"
+prompt_path: "./default_prompt.txt"
 
 # Models
 embedding_model_id: "BAAI/bge-small-en-v1.5"

--- a/EdgeCraftRAG/ui/gradio/ecrag_client.py
+++ b/EdgeCraftRAG/ui/gradio/ecrag_client.py
@@ -78,7 +78,7 @@ def create_update_pipeline(
         ],
         generator=api_schema.GeneratorIn(
             # TODO: remove hardcoding
-            prompt_path="./edgecraftrag/prompt_template/default_prompt.txt",
+            prompt_path="./default_prompt.txt",
             model=api_schema.ModelIn(model_id=llm_id, model_path=llm_path, device=llm_device, weight=llm_weights),
             inference_type=llm_infertype,
         ),


### PR DESCRIPTION
Fixes [https://github.com/opea-project/GenAIExamples/security/code-scanning/21](https://github.com/opea-project/GenAIExamples/security/code-scanning/21)

To fix the problem, we need to ensure that the `template` path is validated before being used. We can achieve this by normalizing the path and ensuring it is within a predefined safe directory. This will prevent path traversal attacks and ensure that only files within the allowed directory can be accessed.

1. Define a safe root directory where the templates are stored.
2. Normalize the `template` path using `os.path.normpath`.
3. Check that the normalized path starts with the safe root directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
