### PR TITLE
Adjustments for helm release change

### DIFF
--- a/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/README.md
+++ b/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/README.md
@@ -69,10 +69,6 @@ Results will be displayed in the terminal and saved as CSV file named `1_stats.c
   - Persistent Volume Claim (PVC): This is the recommended approach for production setups. For more details on using PVC, refer to [PVC](https://github.com/opea-project/GenAIInfra/blob/main/helm-charts/README.md#using-persistent-volume).
   - Local Host Path: For simpler testing, ensure that each node involved in the deployment follows the steps above to locally prepare the models. After preparing the models, use `--set global.modelUseHostPath=${MODELDIR}` in the deployment command.
 
-- Add OPEA Helm Repository:
-  ```bash
-  python deploy.py --add-repo
-  ```
 - Label Nodes
   ```base
   python deploy.py --add-label --num-nodes 2
@@ -192,13 +188,9 @@ All the test results will come to the folder `GenAIEval/evals/benchmark/benchmar
 
 ## Teardown
 
-After completing the benchmark, use the following commands to clean up the environment:
+After completing the benchmark, use the following command to clean up the environment:
 
 Remove Node Labels:
-```base
-python deploy.py --delete-label
-```
-Delete the OPEA Helm Repository:
 ```bash
-python deploy.py --delete-repo
+python deploy.py --delete-label
 ```

--- a/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/deploy.py
+++ b/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/deploy.py
@@ -112,14 +112,14 @@ def install_helm_release(release_name, chart_name, namespace, values_file, devic
     if device_type == "gaudi":
         print("Device type is gaudi. Pulling Helm chart to get gaudi-values.yaml...")
 
+        # Combine chart_name with fixed prefix
+        chart_pull_url = f"oci://ghcr.io/opea-project/charts/{chart_name}"
+
         # Pull and untar the chart
-        subprocess.run(["helm", "pull", chart_name, "--untar"], check=True)
+        subprocess.run(["helm", "pull", chart_pull_url, "--untar"], check=True)
 
-        # Determine the directory name (get the actual chart_name if chart_name is in the format 'repo_name/chart_name', else use chart_name directly)
-        chart_dir_name = chart_name.split("/")[-1] if "/" in chart_name else chart_name
-
-        # Find the untarred directory (assumes only one directory matches chart_dir_name)
-        untar_dirs = glob.glob(f"{chart_dir_name}*")
+        # Find the untarred directory
+        untar_dirs = glob.glob(f"{chart_name}*")
         if untar_dirs:
             untar_dir = untar_dirs[0]
             hw_values_file = os.path.join(untar_dir, "gaudi-values.yaml")
@@ -190,8 +190,8 @@ def main():
     parser.add_argument(
         "--chart-name",
         type=str,
-        default="opea/chatqna",
-        help="The chart name to deploy, composed of repo name and chart name (default: opea/chatqna).",
+        default="chatqna",
+        help="The chart name to deploy, composed of repo name and chart name (default: chatqna).",
     )
     parser.add_argument("--namespace", default="default", help="Kubernetes namespace (default: default).")
     parser.add_argument("--hf-token", help="Hugging Face API token.")

--- a/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/deploy.py
+++ b/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/deploy.py
@@ -83,26 +83,6 @@ def clear_labels_from_nodes(label, node_names=None):
             print(f"Label {label_key} not found on node {node_name}, skipping.")
 
 
-def add_helm_repo(repo_name, repo_url):
-    # Add the repo if it does not exist
-    add_command = ["helm", "repo", "add", repo_name, repo_url]
-    try:
-        subprocess.run(add_command, check=True)
-        print(f"Added Helm repo {repo_name} from {repo_url}.")
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to add Helm repo {repo_name}: {e}")
-
-
-def delete_helm_repo(repo_name):
-    """Delete Helm repo if it exists."""
-    command = ["helm", "repo", "remove", repo_name]
-    try:
-        subprocess.run(command, check=True)
-        print(f"Deleted Helm repo {repo_name}.")
-    except subprocess.CalledProcessError:
-        print(f"Failed to delete Helm repo {repo_name}. It may not exist.")
-
-
 def install_helm_release(release_name, chart_name, namespace, values_file, device_type):
     """Deploy a Helm release with a specified name and chart.
 
@@ -218,12 +198,6 @@ def main():
     parser.add_argument(
         "--model-dir", help="Model directory, mounted as volumes for service access to pre-downloaded models"
     )
-    parser.add_argument("--repo-name", default="opea", help="Helm repo name to add/delete (default: opea).")
-    parser.add_argument(
-        "--repo-url",
-        default="https://opea-project.github.io/GenAIInfra",
-        help="Helm repository URL (default: https://opea-project.github.io/GenAIInfra).",
-    )
     parser.add_argument("--user-values", help="Path to a user-specified values.yaml file.")
     parser.add_argument(
         "--create-values-only", action="store_true", help="Only create the values.yaml file without deploying."
@@ -244,8 +218,6 @@ def main():
         action="store_true",
         help="Modify resources for services and change extraCmdArgs when creating values.yaml.",
     )
-    parser.add_argument("--add-repo", action="store_true", help="Add the Helm repo specified by --repo-url.")
-    parser.add_argument("--delete-repo", action="store_true", help="Delete the Helm repo specified by --repo-name.")
     parser.add_argument(
         "--device-type",
         type=str,
@@ -263,14 +235,6 @@ def main():
             parser.error("--num-nodes must match the number of --node-names if both are specified.")
         else:
             args.num_nodes = num_node_names
-
-    # Helm repository management
-    if args.add_repo:
-        add_helm_repo(args.repo_name, args.repo_url)
-        return
-    elif args.delete_repo:
-        delete_helm_repo(args.repo_name)
-        return
 
     # Node labeling management
     if args.add_label:


### PR DESCRIPTION
The way that Helm Chart Release has been changed, charts can now be installed from oci://ghcr.io/opea-project/charts without the need to add a repository. Make update in this implementation accordingly.

opea-project/GenAIInfra#592