### PR TITLE
[ChatQnA] Update Benchmark E2E Parameters

### DIFF
--- a/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/README.md
+++ b/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/README.md
@@ -165,6 +165,7 @@ Use the following `cURL` command to upload file:
 cd GenAIEval/evals/benchmark/data
 curl -X POST "http://${cluster_ip}:6007/v1/dataprep" \
      -H "Content-Type: multipart/form-data" \
+     -F "chunk_size=3800" \
      -F "files=@./upload_file.txt"
 ```
 

--- a/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/README.md
+++ b/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/README.md
@@ -146,7 +146,6 @@ Before testing, upload a specified file to make sure the llm input have the toke
 Get files:
 
 ```bash
-wget https://github.com/opea-project/GenAIEval/tree/main/evals/benchmark/data/upload_file_no_rerank.txt
 wget https://github.com/opea-project/GenAIEval/tree/main/evals/benchmark/data/upload_file.txt
 ```
 
@@ -164,14 +163,9 @@ Use the following `cURL` command to upload file:
 
 ```bash
 cd GenAIEval/evals/benchmark/data
-# RAG with Rerank
 curl -X POST "http://${cluster_ip}:6007/v1/dataprep" \
      -H "Content-Type: multipart/form-data" \
      -F "files=@./upload_file.txt"
-# RAG without Rerank
-curl -X POST "http://${cluster_ip}:6007/v1/dataprep" \
-     -H "Content-Type: multipart/form-data" \
-     -F "files=@./upload_file_no_rerank.txt"
 ```
 
 #### Run Benchmark Test

--- a/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/benchmark.yaml
+++ b/ChatQnA/benchmark/performance/kubernetes/intel/gaudi/benchmark.yaml
@@ -37,7 +37,7 @@ test_cases:
       service_name: "chatqna-retriever-usvc"  # Replace with your service name
       parameters:
         search_type: "similarity"
-        k: 4
+        k: 1
         fetch_k: 20
         lambda_mult: 0.5
         score_threshold: 0.2
@@ -65,3 +65,4 @@ test_cases:
     e2e:
       run_test: true
       service_name: "chatqna"  # Replace with your service name
+      k: 1


### PR DESCRIPTION
## Description

Modify Retrieval top_k Parameter to 1, to align with/without rerank pipeline llm input token length.

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Local tested
