### PR TITLE
[ChatQNA] Fix K8s Deployment for CPU/HPU

### DIFF
--- a/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna-guardrails.yaml
+++ b/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna-guardrails.yaml
@@ -541,11 +541,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         {}

--- a/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna-remote-inference.yaml
+++ b/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna-remote-inference.yaml
@@ -545,11 +545,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         {}

--- a/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna.yaml
+++ b/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna.yaml
@@ -441,11 +441,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
-        app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/instance: chatqna        
     spec:
       securityContext:
         {}

--- a/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna_bf16.yaml
+++ b/ChatQnA/kubernetes/intel/cpu/xeon/manifest/chatqna_bf16.yaml
@@ -442,11 +442,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         {}

--- a/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna-guardrails.yaml
+++ b/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna-guardrails.yaml
@@ -543,11 +543,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         {}

--- a/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna-vllm-remote-inference.yaml
+++ b/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna-vllm-remote-inference.yaml
@@ -453,11 +453,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         {}

--- a/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna-vllm.yaml
+++ b/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna-vllm.yaml
@@ -585,11 +585,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         {}

--- a/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna.yaml
+++ b/ChatQnA/kubernetes/intel/hpu/gaudi/manifest/chatqna.yaml
@@ -442,11 +442,8 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: chatqna-ui-1.0.0
         app.kubernetes.io/name: chatqna-ui
         app.kubernetes.io/instance: chatqna
-        app.kubernetes.io/version: "v1.0"
-        app.kubernetes.io/managed-by: Helm
     spec:
       securityContext:
         {}


### PR DESCRIPTION
## Description

The PR fixes the deployment yamls for ChatQNA in cpu/hpu based k8s clusters.
The issue was with disconnect between the `labelSelector` in chatqna-ui service and labels applied by chatqna-ui deployment to pods. As service would only be able to route the traffic if `labelSelector` has the exact same match of labels applied to the pods. 

So keeping consistency with other deployment and services, updates the labels applied to chatqna-ui pods

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
