### PR TITLE
Misc Dockerfiles updates to reduce image footprints

### DIFF
--- a/ChatQnA/Dockerfile
+++ b/ChatQnA/Dockerfile
@@ -1,30 +1,50 @@
-
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-FROM python:3.11-slim
+ARG IMAGE_NAME=python
+ARG IMAGE_TAG=3.11-slim
+FROM ${IMAGE_NAME}:${IMAGE_TAG} as base
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
+ENV LANG C.UTF-8
+
+RUN apt-get update -y && apt-get install -y \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    git
+    libjemalloc-dev && \
+    apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/
 
-WORKDIR /home/user/
-RUN git clone https://github.com/opea-project/GenAIComps.git
-
 WORKDIR /home/user/GenAIComps
+
+FROM base AS devel
+
+ARG GenAICompsRepo="https://github.com/opea-project/GenAIComps"
+ARG GenAICompsBranch="main"  # Branch name or Commit ID
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
+    curl
+
+RUN curl -sSL --retry 5 ${GenAICompsRepo}/tarball/${GenAICompsBranch} | tar --strip-components=1 -xzf -
+
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
     pip install --no-cache-dir -r /home/user/GenAIComps/requirements.txt && \
     pip install --no-cache-dir langchain_core
 
+FROM base AS prod
+
+ARG PYTHON=python3.11
+
 COPY ./chatqna.py /home/user/chatqna.py
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user/GenAIComps
+
+COPY --from=devel /usr/local/lib/${PYTHON}/site-packages /usr/local/lib/${PYTHON}/site-packages
+COPY --from=devel /usr/local/bin /usr/local/bin
+COPY --from=devel /home/user/GenAIComps /home/user/GenAIComps
 
 USER user
 


### PR DESCRIPTION
## Description
This PR, leverages multi-stage builds and a few other BKMs to reduce Docker image footprints as much as possible and still sticking with same base images and ensuring functionality remains intact.
Once the two images (one from `main` branch and one using Dockerfile provided in this PR) are built the results shows 20%+ image size reduction:
```
$ docker images | grep chatqna
chatqna                updated         a16d17afc110   12 minutes ago   649MB
chatqna                main            ef7dccfe29d2   15 minutes ago   828MB
```

There are a few other enhancements like introducing `build-args` for GenAIComps repo and branch names to be cloned which improves local development and testing experience and is less error prone since it doesn't require modifying the Dockerfiles themselves.

My goal is not to get this PR merged, but I like some early feedback review so that we can collect other BKMs into one before going after all Dockerfiles and decide to improve every single one of them.

## Issues
This is a known issue.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)

## Dependencies
N/A

## Tests
This is a WIP PR and there is a CI test to cover it as well.