### PR TITLE
Refactor vllm openvino to third parties

### DIFF
--- a/EdgeCraftRAG/tests/test_compose_vllm_on_arc.sh
+++ b/EdgeCraftRAG/tests/test_compose_vllm_on_arc.sh
@@ -39,7 +39,7 @@ function build_docker_images() {
 
     echo "Build vllm_openvino image from GenAIComps..."
     cd $WORKPATH && git clone https://github.com/opea-project/GenAIComps.git && cd GenAIComps && git checkout "${opea_branch:-"main"}"
-    cd comps/llms/text-generation/vllm/langchain/dependency
+    cd comps/third_parties/vllm/src/
     bash ./build_docker_vllm_openvino.sh gpu
 
     docker images && sleep 1s


### PR DESCRIPTION
## Description

vllm-openvino is a dependency for text generation comps, in GenAIComps PR https://github.com/opea-project/GenAIComps/pull/1141 we move it to third-parties folder, update the path accordingly.

## Issues

#998 

## Type of change

List the type of change like below. Please delete options that are not relevant.

-  Others (enhancement, documentation, validation, etc.)

## Dependencies

no

## Tests

EdgeCraftRAG/tests/test_compose_vllm_on_arc.sh
EdgeCraftRAG/tests/test_compose_on_arc.sh
