### PR TITLE
Fix Domain Access Issue in Latest Vite Version

### DIFF
--- a/AgentQnA/ui/svelte/vite.config.ts
+++ b/AgentQnA/ui/svelte/vite.config.ts
@@ -7,14 +7,7 @@ import type { UserConfig } from "vite";
 const config: UserConfig = {
 	plugins: [sveltekit()],
 	server: {
-		proxy: {
-			"/api": {
-				target: "http://10.112.228.168:8000",
-				changeOrigin: true,
-				secure: true,
-				rewrite: (path) => path.replace(/^\/api/, ""),
-			},
-		},
+		allowedHosts: true
 	},
 };
 

--- a/AudioQnA/ui/svelte/vite.config.ts
+++ b/AudioQnA/ui/svelte/vite.config.ts
@@ -17,6 +17,9 @@ import type { UserConfig } from "vite";
 
 const config: UserConfig = {
 	plugins: [sveltekit()],
+	server: {
+		allowedHosts: true
+	},
 };
 
 export default config;

--- a/ChatQnA/ui/svelte/vite.config.ts
+++ b/ChatQnA/ui/svelte/vite.config.ts
@@ -17,7 +17,9 @@ import type { UserConfig } from "vite";
 
 const config: UserConfig = {
 	plugins: [sveltekit()],
-	server: {},
+	server: {
+		allowedHosts: true
+	},
 };
 
 export default config;

--- a/CodeGen/ui/svelte/vite.config.ts
+++ b/CodeGen/ui/svelte/vite.config.ts
@@ -17,7 +17,9 @@ import type { UserConfig } from "vite";
 
 const config: UserConfig = {
 	plugins: [sveltekit()],
-	server: {},
+	server: {
+		allowedHosts: true
+	},
 };
 
 export default config;

--- a/CodeTrans/ui/svelte/vite.config.ts
+++ b/CodeTrans/ui/svelte/vite.config.ts
@@ -17,4 +17,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [sveltekit()],
+  server: {
+		allowedHosts: true
+	},
 });

--- a/DocSum/ui/svelte/vite.config.ts
+++ b/DocSum/ui/svelte/vite.config.ts
@@ -16,8 +16,10 @@ import { sveltekit } from "@sveltejs/kit/vite";
 import type { UserConfig } from "vite";
 
 const config: UserConfig = {
-  plugins: [sveltekit()],
-  server: {},
+	plugins: [sveltekit()],
+	server: {
+		allowedHosts: true
+	},
 };
 
 export default config;

--- a/FaqGen/ui/svelte/vite.config.ts
+++ b/FaqGen/ui/svelte/vite.config.ts
@@ -16,8 +16,10 @@ import { sveltekit } from "@sveltejs/kit/vite";
 import type { UserConfig } from "vite";
 
 const config: UserConfig = {
-  plugins: [sveltekit()],
-  server: {},
+	plugins: [sveltekit()],
+	server: {
+		allowedHosts: true
+	},
 };
 
 export default config;

--- a/GraphRAG/ui/svelte/vite.config.ts
+++ b/GraphRAG/ui/svelte/vite.config.ts
@@ -6,7 +6,9 @@ import type { UserConfig } from "vite";
 
 const config: UserConfig = {
 	plugins: [sveltekit()],
-	server: {},
+	server: {
+		allowedHosts: true
+	},
 };
 
 export default config;

--- a/SearchQnA/ui/svelte/vite.config.ts
+++ b/SearchQnA/ui/svelte/vite.config.ts
@@ -17,7 +17,9 @@ import type { UserConfig } from "vite";
 
 const config: UserConfig = {
 	plugins: [sveltekit()],
-	server: {},
+	server: {
+		allowedHosts: true
+	},
 };
 
 export default config;

--- a/Text2Image/ui/svelte/vite.config.ts
+++ b/Text2Image/ui/svelte/vite.config.ts
@@ -18,8 +18,7 @@ import type { UserConfig } from "vite";
 const config: UserConfig = {
 	plugins: [sveltekit()],
 	server: {
-		host: "0.0.0.0",
-		port: 5173,
+		allowedHosts: true
 	},
 };
 

--- a/Translation/ui/svelte/vite.config.ts
+++ b/Translation/ui/svelte/vite.config.ts
@@ -17,4 +17,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [sveltekit()],
+  server: {
+		allowedHosts: true
+	},
 });

--- a/VisualQnA/ui/svelte/vite.config.ts
+++ b/VisualQnA/ui/svelte/vite.config.ts
@@ -17,7 +17,8 @@ import type { UserConfig } from "vite";
 
 const config: UserConfig = {
 	plugins: [sveltekit()],
-	server: {},
+	server: {
+		allowedHosts: true
+	},
 };
-
 export default config;


### PR DESCRIPTION

## Description

Fix the restriction on using domain names when users are using the latest version of Vite

When users use the new version of Vite, the UI cannot be accessed via domain names due to Vite's new rules. This fix adds the corresponding parameters according to Vite's new rules, ensuring that users can access the frontend via domain names when building the UI.

Fixes #1441

## Issues

[List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.
](https://github.com/opea-project/GenAIExamples/issues/1441)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

the latest vite version

## Tests

CI pass.