### PR TITLE
remove image build condition

### DIFF
--- a/.github/workflows/_example-workflow.yml
+++ b/.github/workflows/_example-workflow.yml
@@ -50,7 +50,6 @@ jobs:
 # Image Build
 ####################################################################################################
   build-images:
-    if: ${{ !(fromJSON(inputs.test_helmchart)) }}
     runs-on: "docker-build-${{ inputs.node }}"
     steps:
       - name: Clean Up Working Directory


### PR DESCRIPTION
## Description

Test compose cd workflow depend on image build, so if we want to run both compose and helm charts deployment in cd workflow, this condition should be removed. 

## Issues

https://github.com/opea-project/GenAIExamples/actions/runs/12911771576
While testing both docker compose and helm charts, test only trigger helm chart. 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
