### PR TITLE
Check for llava-tgi-service being started rather than healthy

### DIFF
--- a/VisualQnA/docker_compose/intel/cpu/xeon/compose.yaml
+++ b/VisualQnA/docker_compose/intel/cpu/xeon/compose.yaml
@@ -28,7 +28,7 @@ services:
     container_name: lvm-xeon-server
     depends_on:
       llava-tgi-service:
-        condition: service_healthy
+        condition: service_started  # service_healthy
     ports:
       - "9399:9399"
     ipc: host


### PR DESCRIPTION
## Description
For some reason, `llava-tgi-service` never becomes healthy and the dependent services within `VisualQnA` fail to start and eventually `docker compose -d up` fails on CPU.
This is probably a subtle bug in the way docker compose healthcheck works. 

## Issues
Although may not be the exact reason that the user is running into issues here #1479 but it may partially resolve that issue

## Type of change
Replace docker compose readiness condition `service_started` instead of `service_healthy`
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies
N/a

## Tests
I can successfully start the services and make `curl` calls to the microservice(s).
