### PR TITLE
Fix docker compose.yaml error

### DIFF
--- a/DocSum/docker_compose/intel/hpu/gaudi/compose.yaml
+++ b/DocSum/docker_compose/intel/hpu/gaudi/compose.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - ${LLM_ENDPOINT_PORT:-8008}:80
     volumes:
-      - "${DATA_PATH:-data}:/data"
+      - "${DATA_PATH:-./data}:/data"
     environment:
       no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}

--- a/FaqGen/docker_compose/intel/hpu/gaudi/compose.yaml
+++ b/FaqGen/docker_compose/intel/hpu/gaudi/compose.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - ${LLM_ENDPOINT_PORT:-8008}:80
     volumes:
-      - "${DATA_PATH:-data}:/data"
+      - "${DATA_PATH:-./data}:/data"
     environment:
       no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}


### PR DESCRIPTION
Docker Compose requires all named volumes to be explicitly defined.

Fix github issue #1486

## Description

The summary of the proposed changes as long as the relevant motivation and context.

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

docker compose up -d
without error response

Without the fix, there is error:
service "tgi-gaudi-server" refers to undefined volume data: invalid compose project
