### PR TITLE
change gaudi node exporter from default one to 41612 

### DIFF
--- a/ChatQnA/docker_compose/intel/hpu/gaudi/compose.telemetry.yaml
+++ b/ChatQnA/docker_compose/intel/hpu/gaudi/compose.telemetry.yaml
@@ -78,7 +78,7 @@ services:
       - /:/rootfs:ro
       - /dev:/dev
     ports:
-      - 41611:41611
+      - 41612:41611
     restart: always
     deploy:
       mode: global

--- a/ChatQnA/docker_compose/intel/hpu/gaudi/compose_tgi.telemetry.yaml
+++ b/ChatQnA/docker_compose/intel/hpu/gaudi/compose_tgi.telemetry.yaml
@@ -80,7 +80,7 @@ services:
       - /:/rootfs:ro
       - /dev:/dev
     ports:
-      - 41611:41611
+      - 41612:41611
     restart: always
     deploy:
       mode: global

--- a/ChatQnA/docker_compose/intel/hpu/gaudi/set_env.sh
+++ b/ChatQnA/docker_compose/intel/hpu/gaudi/set_env.sh
@@ -83,11 +83,11 @@ export NUM_CARDS=${NUM_CARDS}
 export host_ip=${host_ip}
 export http_proxy=${http_proxy}
 export https_proxy=${https_proxy}
-export no_proxy=${no_proxy}
 export LOGFLAG=${LOGFLAG}
 export JAEGER_IP=${JAEGER_IP}
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT}
 export TELEMETRY_ENDPOINT=${TELEMETRY_ENDPOINT}
+export no_proxy="${no_proxy},chatqna-gaudi-ui-server,chatqna-gaudi-backend-server,dataprep-redis-service,tei-embedding-service,retriever,tei-reranking-service,tgi-service,vllm-service,guardrails,jaeger,prometheus,grafana,gaudi-exporter,node-exporter,$JAEGER_IP"
 EOF
 
 echo ".env file has been created with the following content:"


### PR DESCRIPTION

## Description

The gaudi node exporter on the host system might occupy the port 41611 so gaudi node exporter created by docker compose will have issues to use the same port 41611.
change port mapping to map to port 41612 instead. 

## Issues

 `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

NA

## Tests

manually test on gaudi2
