### PR TITLE
Expand example running timeout for the new test cluster with k8s runner set

### DIFF
--- a/.github/workflows/_run-docker-compose.yml
+++ b/.github/workflows/_run-docker-compose.yml
@@ -165,7 +165,7 @@ jobs:
               export model_cache="~/.cache/huggingface/hub"
             fi
           fi
-          if [ -f "${test_case}" ]; then timeout 30m bash "${test_case}"; else echo "Test script {${test_case}} not found, skip test!"; fi
+          if [ -f "${test_case}" ]; then timeout 60m bash "${test_case}"; else echo "Test script {${test_case}} not found, skip test!"; fi
 
       - name: Clean up container after test
         shell: bash

--- a/AudioQnA/tests/test_compose_on_xeon.sh
+++ b/AudioQnA/tests/test_compose_on_xeon.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
-# for test
 
 set -e
 IMAGE_REPO=${IMAGE_REPO:-"opea"}

--- a/AudioQnA/tests/test_compose_on_xeon.sh
+++ b/AudioQnA/tests/test_compose_on_xeon.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+# for test
 
 set -e
 IMAGE_REPO=${IMAGE_REPO:-"opea"}


### PR DESCRIPTION
## Description

Expand example running timeout for the new test cluster with k8s runner set

## Issues

The new runner set with ARC able to run 8 examples cases + 8 comps cases in parallel, which widely enhance the test resource dispatch. Meanwhile need to expand the example timeout limitation. 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
