### PR TITLE
Fix ChatQnA UI issue in set_env.sh on Xeon

### DIFF
--- a/ChatQnA/README.md
+++ b/ChatQnA/README.md
@@ -80,11 +80,11 @@ To set up environment variables for deploying ChatQnA services, follow these ste
    # on Gaudi
    cd GenAIExamples/ChatQnA/docker_compose/intel/hpu/gaudi/
    source ./set_env.sh
-   export no_proxy="Your_No_Proxy",chatqna-gaudi-ui-server,chatqna-gaudi-backend-server,dataprep-redis-service,tei-embedding-service,retriever,tei-reranking-service,tgi-service,vllm-service,guardrails,jaeger,prometheus,grafana,gaudi-node-exporter-1
+   export no_proxy="Your_No_Proxy",chatqna-gaudi-ui-server,chatqna-gaudi-backend-server,dataprep-redis-service,tei-embedding-service,retriever,tei-reranking-service,tgi-service,vllm-service,guardrails,jaeger,prometheus,grafana,node-exporter,gaudi-exporter
    # on Xeon
    cd GenAIExamples/ChatQnA/docker_compose/intel/cpu/xeon/
    source ./set_env.sh
-   export no_proxy="Your_No_Proxy",chatqna-xeon-ui-server,chatqna-xeon-backend-server,dataprep-redis-service,tei-embedding-service,retriever,tei-reranking-service,tgi-service,vllm-service,jaeger,prometheus,grafana,xeon-node-exporter-1
+   export no_proxy="Your_No_Proxy",chatqna-xeon-ui-server,chatqna-xeon-backend-server,dataprep-redis-service,tei-embedding-service,retriever,tei-reranking-service,tgi-service,vllm-service,jaeger,prometheus,grafana,node-exporter
    # on Nvidia GPU
    cd GenAIExamples/ChatQnA/docker_compose/nvidia/gpu
    source ./set_env.sh
@@ -355,11 +355,7 @@ Two ways of consuming ChatQnA Service:
 
 2. Access via frontend
 
-   To access the frontend, open the following URL in your browser: `http://{host_ip}:5173`
-
-   By default, the UI runs on port 5173 internally.
-
-   If you choose conversational UI, use this URL: `http://{host_ip}:5174`
+   To access the frontend, open the following URL in your browser: `http://{host_ip}`
 
 ## Troubleshooting
 

--- a/ChatQnA/docker_compose/intel/cpu/xeon/compose_faqgen.yaml
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/compose_faqgen.yaml
@@ -105,7 +105,7 @@ services:
       vllm-service:
         condition: service_healthy
     ports:
-      - ${LLM_SERVER_PORT:-9000}:9000
+      - ${LLM_FAQGen_HOST_PORT:-9000}:9000
     ipc: host
     environment:
       no_proxy: ${no_proxy}
@@ -141,7 +141,7 @@ services:
       - RERANK_SERVER_HOST_IP=tei-reranking-service
       - RERANK_SERVER_PORT=80
       - LLM_SERVER_HOST_IP=llm-faqgen
-      - LLM_SERVER_PORT=9000
+      - LLM_SERVER_PORT=${LLM_FAQGen_SERVER_PORT}
       - LLM_MODEL=${LLM_MODEL_ID}
       - LOGFLAG=${LOGFLAG}
       - CHATQNA_TYPE=${CHATQNA_TYPE:-CHATQNA_FAQGEN}

--- a/ChatQnA/docker_compose/intel/cpu/xeon/compose_faqgen_tgi.yaml
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/compose_faqgen_tgi.yaml
@@ -105,7 +105,7 @@ services:
       tgi-service:
         condition: service_healthy
     ports:
-      - ${LLM_SERVER_PORT:-9000}:9000
+      - ${LLM_FAQGen_HOST_PORT:-9000}:9000
     ipc: host
     environment:
       no_proxy: ${no_proxy}
@@ -141,7 +141,7 @@ services:
       - RERANK_SERVER_HOST_IP=tei-reranking-service
       - RERANK_SERVER_PORT=80
       - LLM_SERVER_HOST_IP=llm-faqgen
-      - LLM_SERVER_PORT=9000
+      - LLM_SERVER_PORT=${LLM_FAQGen_SERVER_PORT}
       - LLM_MODEL=${LLM_MODEL_ID}
       - LOGFLAG=${LOGFLAG}
       - CHATQNA_TYPE=${CHATQNA_TYPE:-CHATQNA_FAQGEN}

--- a/ChatQnA/docker_compose/intel/cpu/xeon/set_env.sh
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/set_env.sh
@@ -22,12 +22,10 @@ export TELEMETRY_ENDPOINT=http://$JAEGER_IP:4318/v1/traces
 export no_proxy="$no_proxy,chatqna-xeon-ui-server,chatqna-xeon-backend-server,dataprep-redis-service,tei-embedding-service,retriever,tei-reranking-service,tgi-service,vllm-service,jaeger,prometheus,grafana,node-exporter,$JAEGER_IP"
 
 export LLM_ENDPOINT_PORT=8010
-export LLM_SERVER_PORT=9000
 export CHATQNA_BACKEND_PORT=8888
 export CHATQNA_REDIS_VECTOR_PORT=6379
 export CHATQNA_REDIS_VECTOR_INSIGHT_PORT=8001
 export CHATQNA_FRONTEND_SERVICE_PORT=5173
-export NGINX_PORT=80
 export FAQGen_COMPONENT_NAME="OpeaFaqGenvLLM"
 export LLM_ENDPOINT="http://${host_ip}:${LLM_ENDPOINT_PORT}"
 pushd "grafana/dashboards" > /dev/null

--- a/ChatQnA/docker_compose/intel/cpu/xeon/set_env.sh
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/set_env.sh
@@ -27,6 +27,8 @@ export CHATQNA_REDIS_VECTOR_PORT=6379
 export CHATQNA_REDIS_VECTOR_INSIGHT_PORT=8001
 export CHATQNA_FRONTEND_SERVICE_PORT=5173
 export FAQGen_COMPONENT_NAME="OpeaFaqGenvLLM"
+export LLM_FAQGen_SERVER_PORT=9000
+export LLM_FAQGen_HOST_PORT=9000
 export LLM_ENDPOINT="http://${host_ip}:${LLM_ENDPOINT_PORT}"
 pushd "grafana/dashboards" > /dev/null
 source download_opea_dashboard.sh


### PR DESCRIPTION
## Description

Set the wrong port in set_env.sh. remove the port setting and also direct users to use nginx using http://IP:80 instead of port 5173

## Issues

[issue#1658.](https://github.com/opea-project/GenAIExamples/issues/1658)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

na

## Tests

test on Xeon
