### PR TITLE
Optimize the nightly/weekly example test

### DIFF
--- a/.github/workflows/nightly-docker-build-publish.yml
+++ b/.github/workflows/nightly-docker-build-publish.yml
@@ -39,8 +39,7 @@ jobs:
       node: gaudi
 
   build-images:
-    needs: [build-comps-base]
-    if: ${{ needs.get-build-matrix.outputs.examples_json != '' }}
+    needs: [get-build-matrix, build-comps-base]
     strategy:
       matrix:
         example: ${{ fromJSON(needs.get-build-matrix.outputs.examples_json) }}
@@ -75,7 +74,7 @@ jobs:
       examples: ${{ needs.get-build-matrix.outputs.EXAMPLES }}
 
   publish:
-    needs: [build-images]
+    needs: [get-image-list, build-images]
     if: always()
     strategy:
       matrix:

--- a/.github/workflows/nightly-docker-build-publish.yml
+++ b/.github/workflows/nightly-docker-build-publish.yml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  # EXAMPLES: ${{ vars.NIGHTLY_RELEASE_EXAMPLES }}
-  EXAMPLES: "CodeGen,DocSum"
+  EXAMPLES: ${{ vars.NIGHTLY_RELEASE_EXAMPLES }}
   TAG: "latest"
   PUBLISH_TAGS: "latest"
 

--- a/.github/workflows/nightly-docker-build-publish.yml
+++ b/.github/workflows/nightly-docker-build-publish.yml
@@ -75,7 +75,7 @@ jobs:
       examples: ${{ needs.get-build-matrix.outputs.EXAMPLES }}
 
   publish:
-    needs: [get-image-list, build-images]
+    needs: [get-build-matrix, get-image-list, build-images]
     if: always()
     strategy:
       matrix:

--- a/.github/workflows/nightly-docker-build-publish.yml
+++ b/.github/workflows/nightly-docker-build-publish.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 env:
-  EXAMPLES: ${{ vars.NIGHTLY_RELEASE_EXAMPLES }}
+  # EXAMPLES: ${{ vars.NIGHTLY_RELEASE_EXAMPLES }}
+  EXAMPLES: "CodeGen,DocSum"
   TAG: "latest"
   PUBLISH_TAGS: "latest"
 

--- a/.github/workflows/nightly-docker-build-publish.yml
+++ b/.github/workflows/nightly-docker-build-publish.yml
@@ -5,7 +5,7 @@ name: Nightly build/publish latest docker images
 
 on:
   schedule:
-    - cron: "30 14 * * *" # UTC time
+    - cron: "30 14 * * 1-5" # UTC time
   workflow_dispatch:
 
 env:
@@ -38,8 +38,22 @@ jobs:
     with:
       node: gaudi
 
-  build-and-test:
-    needs: get-build-matrix
+  build-images:
+    needs: [build-comps-base]
+    if: ${{ needs.get-build-matrix.outputs.examples_json != '' }}
+    strategy:
+      matrix:
+        example: ${{ fromJSON(needs.get-build-matrix.outputs.examples_json) }}
+      fail-fast: false
+    uses: ./.github/workflows/_build_image.yml
+    with:
+      node: gaudi
+      example: ${{ matrix.example }}
+      inject_commit: true
+    secrets: inherit
+
+  test-example:
+    needs: [get-build-matrix]
     if: ${{ needs.get-build-matrix.outputs.examples_json != '' }}
     strategy:
       matrix:
@@ -47,21 +61,22 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/_example-workflow.yml
     with:
-      node: gaudi
+      node: xeon
+      build: false
       example: ${{ matrix.example }}
       test_compose: true
       inject_commit: true
     secrets: inherit
 
   get-image-list:
-    needs: get-build-matrix
+    needs: [get-build-matrix]
     uses: ./.github/workflows/_get-image-list.yml
     with:
       examples: ${{ needs.get-build-matrix.outputs.EXAMPLES }}
 
   publish:
-    needs: [get-build-matrix, get-image-list, build-and-test]
-    if: always() && ${{ needs.get-image-list.outputs.matrix != '' }}
+    needs: [build-images]
+    if: always()
     strategy:
       matrix:
         image: ${{ fromJSON(needs.get-image-list.outputs.matrix) }}

--- a/.github/workflows/weekly-example-test.yml
+++ b/.github/workflows/weekly-example-test.yml
@@ -9,8 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  # EXAMPLES: ${{ vars.NIGHTLY_RELEASE_EXAMPLES }}
-  EXAMPLES: "CodeGen,CodeTrans"
+  EXAMPLES: ${{ vars.NIGHTLY_RELEASE_EXAMPLES }}
   NODES: "gaudi,xeon,rocm,arc"
 
 jobs:
@@ -26,7 +25,7 @@ jobs:
           examples=($(echo ${EXAMPLES} | tr ',' ' '))
           examples_json=$(printf '%s\n' "${examples[@]}" | sort -u | jq -R '.' | jq -sc '.')
           echo "examples=$examples_json" >> $GITHUB_OUTPUT
-          nodes=($(echo ${{ NODES }} | tr ',' ' '))
+          nodes=($(echo ${NODES} | tr ',' ' '))
           nodes_json=$(printf '%s\n' "${nodes[@]}" | sort -u | jq -R '.' | jq -sc '.')
           echo "nodes=$nodes_json" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/weekly-example-test.yml
+++ b/.github/workflows/weekly-example-test.yml
@@ -1,0 +1,57 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: Weekly test all examples on multiple HWs
+
+on:
+  schedule:
+    - cron: "30 2 * * 6" # UTC time
+  workflow_dispatch:
+
+env:
+  # EXAMPLES: ${{ vars.NIGHTLY_RELEASE_EXAMPLES }}
+  EXAMPLES: "CodeGen,CodeTrans"
+  NODES: "gaudi,xeon,rocm,arc"
+
+jobs:
+  get-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      examples: ${{ steps.get-matrix.outputs.examples }}
+      nodes: ${{ steps.get-matrix.outputs.nodes }}
+    steps:
+      - name: Create Matrix
+        id: get-matrix
+        run: |
+          examples=($(echo ${EXAMPLES} | tr ',' ' '))
+          examples_json=$(printf '%s\n' "${examples[@]}" | sort -u | jq -R '.' | jq -sc '.')
+          echo "examples=$examples_json" >> $GITHUB_OUTPUT
+          nodes=($(echo ${{ NODES }} | tr ',' ' '))
+          nodes_json=$(printf '%s\n' "${nodes[@]}" | sort -u | jq -R '.' | jq -sc '.')
+          echo "nodes=$nodes_json" >> $GITHUB_OUTPUT
+
+  build-comps-base:
+    needs: [get-test-matrix]
+    strategy:
+      matrix:
+        node: ${{ fromJson(needs.get-test-matrix.outputs.nodes) }}
+    uses: ./.github/workflows/_build_comps_base_image.yml
+    with:
+      node: ${{ matrix.node }}
+
+  run-examples:
+    needs: [get-test-matrix, build-comps-base]
+    strategy:
+      matrix:
+        example: ${{ fromJson(needs.get-test-matrix.outputs.examples) }}
+        node: ${{ fromJson(needs.get-test-matrix.outputs.nodes) }}
+      fail-fast: false
+    uses: ./.github/workflows/_example-workflow.yml
+    with:
+      node: ${{ matrix.node }}
+      example: ${{ matrix.example }}
+      build: true
+      test_compose: true
+      test_helmchart: true
+    secrets: inherit
+

--- a/.github/workflows/weekly-example-test.yml
+++ b/.github/workflows/weekly-example-test.yml
@@ -54,4 +54,3 @@ jobs:
       test_compose: true
       test_helmchart: true
     secrets: inherit
-


### PR DESCRIPTION
## Description

1. CICD infrastructure has more test resource on Xeon than Gaudi, so move the nightly test from Gaudi to Xeon. 
2. Xeon image registry only has 1TB disk, so keep image build on Gaudi which has 7TB. 
3. Add weekly job test examples on all HWs we supported in CI. 

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
