### PR TITLE
Remove template_llava.jinja in command

### DIFF
--- a/VisualQnA/docker_compose/intel/cpu/xeon/compose.yaml
+++ b/VisualQnA/docker_compose/intel/cpu/xeon/compose.yaml
@@ -20,7 +20,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 100
-    command: --model $LVM_MODEL_ID --host 0.0.0.0 --port 80 --chat-template examples/template_llava.jinja  # https://docs.vllm.ai/en/v0.5.0/models/vlm.html
+    command: --model $LVM_MODEL_ID --host 0.0.0.0 --port 80 # --chat-template examples/template_llava.jinja  # https://docs.vllm.ai/en/v0.5.0/models/vlm.html
 
   lvm:
     image: ${REGISTRY:-opea}/lvm:${TAG:-latest}


### PR DESCRIPTION
## Description

Remove template_llava.jinja in command since its no longer included in default vllm image, and pipeline works fine without it.

## Issues

https://github.com/opea-project/GenAIExamples/issues/1808

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

no.

## Tests

UT.
