### PR TITLE
Potential fix for code scanning alert no. 30: Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/_helm-e2e.yml
+++ b/.github/workflows/_helm-e2e.yml
@@ -142,12 +142,15 @@ jobs:
             echo "Error: Input '${example_lower}' is not in the list of folders."
             exit 1
           fi
-
+          if [[ ! "${example_lower}" =~ ^[a-z0-9-]+$ ]]; then
+            echo "Error: Input '${example_lower}' contains invalid characters. Only alphanumeric characters and dashes are allowed."
+            exit 1
+          fi
       - name: Set variables
         env:
           example: ${{ inputs.example }}
         run: |
-          CHART_NAME="${example,,}"  # CodeGen
+          CHART_NAME=$(echo "${example,,}" | tr -cd 'a-z0-9-')  # Sanitize input
           echo "CHART_NAME=$CHART_NAME" >> $GITHUB_ENV
           echo "RELEASE_NAME=${CHART_NAME}$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
           echo "NAMESPACE=${CHART_NAME}-$(head -c 4 /dev/urandom | xxd -p)" >> $GITHUB_ENV


### PR DESCRIPTION
Potential fix for [https://github.com/opea-project/GenAIExamples/security/code-scanning/30](https://github.com/opea-project/GenAIExamples/security/code-scanning/30)

To fix the issue, we need to sanitize the `example` input before using it to construct the `CHART_NAME` environment variable. This can be achieved by ensuring that the input contains only alphanumeric characters and dashes, which are safe for use in environment variables. Any invalid characters should result in an error.

The fix involves:
1. Adding a sanitization step to validate the `example` input and ensure it contains only safe characters.
2. Updating the "Set variables" step to use the sanitized input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
