### PR TITLE
Add if validation to retrieval tool

### DIFF
--- a/AgentQnA/retrieval_tool/run_ingest_data.sh
+++ b/AgentQnA/retrieval_tool/run_ingest_data.sh
@@ -1,7 +1,11 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-host_ip=$(hostname -I | awk '{print $1}')
+# If host_ip is not set, assign it
+if [ -z "$host_ip" ]; then
+  host_ip=$(hostname -I | awk '{print $1}')
+fi
+
 port=6007
 FILEDIR=${WORKDIR}/GenAIExamples/AgentQnA/example_data/
 FILENAME=test_docs_music.jsonl


### PR DESCRIPTION
## Description

Add an `if` condition to check if `host_ip` has already been configured, so the script does not overwrite a manually assigned value. This is important for Kubernetes, where the local `host_ip` address is private to the cluster and not directly accessible instead of the ip captured running `$(hostname -I | awk '{print $1}')`.

Even when using port forwarding, host_ip must be set before running the script. This validation allows the script to work properly in both Docker and Kubernetes environments while still allowing users to specify host_ip manually if needed.

## Issues

n/a
## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ x ] Others (enhancement, documentation, validation, etc.)

## Dependencies


## Tests

N/A. It's just a validation condition