### PR TITLE
[DocSum] Fix dataset addition to run yaml

### DIFF
--- a/DocSum/benchmark_docsum.yaml
+++ b/DocSum/benchmark_docsum.yaml
@@ -5,7 +5,7 @@ deploy:
   device: gaudi
   version: 1.3.0
   modelUseHostPath: /mnt/models
-  HUGGINGFACEHUB_API_TOKEN: "" # mandatory
+  HF_TOKEN: "" # mandatory
   node: [1]
   namespace: ""
   node_name: []

--- a/benchmark.py
+++ b/benchmark.py
@@ -170,6 +170,13 @@ def _create_stresscli_confs(case_params, test_params, test_phase, num_queries, b
             stresscli_conf["envs"] = {"DATASET": test_params["dataset"][i], "MAX_LINES": str(test_params["prompt"][i])}
         else:
             stresscli_conf["envs"] = {"MAX_LINES": str(test_params["prompt"][i])}
+        # Handle dataset for DocSum
+        if b_target in ["docsumbench", "docsumfixed"]:
+            if len(test_params["dataset"]) > i:
+                case_params["dataset"] = test_params["dataset"][i]
+            else:
+                case_params["dataset"] = None
+
         # Generate the content of stresscli configuration file
         stresscli_yaml = _create_yaml_content(
             case_params, base_url, b_target, test_phase, num_queries, test_params, concurrency


### PR DESCRIPTION
  * Fixes how dataset parameters are added to run yaml

## Description

This fixes how dataset parameters are added to the run YAML. Previously, it worked only if the dataset parameter was a string. Now, it works with a list, which was the original intent.

## Issues

'n/a'

## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

- None

## Tests

Tested with both bench_target options and multiple different datasets with bench_target: ["docsumbench"]