### PR TITLE
Add openEuler Helm values for ChatQnA

### DIFF
--- a/ChatQnA/kubernetes/helm/cpu-openeuler-values.yaml
+++ b/ChatQnA/kubernetes/helm/cpu-openeuler-values.yaml
@@ -1,0 +1,58 @@
+# Copyright (C) 2025 Huawei Technologies Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+# This file is based on cpu-values.yaml and overrides image tags to 'latest-openeuler'
+# for all enabled services to run on openEuler.
+
+# Overrides for the main chart image
+image:
+  tag: latest-openeuler
+
+# Overrides from cpu-values.yaml
+vllm:
+  image:
+    repository: openeuler/vllm-cpu
+    tag: 0.10.1-oe2403lts
+  LLM_MODEL_ID: meta-llama/Meta-Llama-3-8B-Instruct
+
+  # Uncomment the following model specific settings for DeepSeek models
+  #VLLM_CPU_KVCACHE_SPACE: 40
+  #resources:
+  #  requests:
+  #    memory: 60Gi # 40G for KV cache, and 20G for DeepSeek-R1-Distill-Qwen-7B, need to adjust it for other models
+
+# Overrides for subchart images
+# Based on the default values in opea-project/GenAIInfra/helm-charts/chatqna/values.yaml,
+# the following services are enabled by default.
+
+# data-prep service
+data-prep:
+  image:
+    tag: latest-openeuler
+
+# retriever-usvc service
+retriever-usvc:
+  image:
+    tag: latest-openeuler
+
+# tei-rerank service
+teirerank:
+  image:
+    repository: openeuler/text-embeddings-inference-cpu
+    tag: 1.7.0-oe2403lts
+
+# tei service
+tei:
+  image:
+    repository: openeuler/text-embeddings-inference-cpu
+    tag: 1.7.0-oe2403lts
+
+# nginx service
+nginx:
+  image:
+    tag: latest-openeuler
+
+# chatqna-ui service
+chatqna-ui:
+  image:
+    tag: latest-openeuler


### PR DESCRIPTION
## Description

This PR adds a new Helm values file, `cpu-openeuler-values.yaml`, to configure the ChatQnA deployment for openEuler compatibility. The file sets image tags and repositories for all enabled services to use openEuler-specific images and versions.

openEuler compatibility configuration:

* Added `cpu-openeuler-values.yaml` with overrides to set all main and subchart image tags to `latest-openeuler` for openEuler support.
* Configured the `vllm` service to use the `openeuler/vllm-cpu` image with a specific tag and set the LLM model to `meta-llama/Meta-Llama-3-8B-Instruct`.
* Updated the `teirerank` service to use the `openeuler/text-embeddings-inference-cpu` image with an openEuler-specific tag.
* Ensured all other enabled services (`data-prep`, `retriever-usvc`, `tei`, `nginx`, `chatqna-ui`) use the `latest-openeuler` image tag.

## Issues

https://github.com/opea-project/GenAIExamples/issues/2264

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
