### PR TITLE
Bump the version of `openeuler/vllm-cpu` to 0.10.1

### DIFF
--- a/AudioQnA/docker_compose/intel/cpu/xeon/compose_openeuler.yaml
+++ b/AudioQnA/docker_compose/intel/cpu/xeon/compose_openeuler.yaml
@@ -25,14 +25,13 @@ services:
       https_proxy: ${https_proxy}
     restart: unless-stopped
   vllm-service:
-    image: openeuler/vllm-cpu:0.9.1-oe2403lts
+    image: openeuler/vllm-cpu:0.10.1-oe2403lts
     container_name: vllm-service
     ports:
       - ${LLM_SERVER_PORT:-3006}:80
     volumes:
       - "${MODEL_CACHE:-./data}:/root/.cache/huggingface/hub"
     shm_size: 128g
-    privileged: true
     environment:
       no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}

--- a/ChatQnA/docker_compose/intel/cpu/xeon/compose_openeuler.yaml
+++ b/ChatQnA/docker_compose/intel/cpu/xeon/compose_openeuler.yaml
@@ -88,14 +88,13 @@ services:
       HF_HUB_ENABLE_HF_TRANSFER: 0
     command: --model-id ${RERANK_MODEL_ID} --auto-truncate
   vllm-service:
-    image: openeuler/vllm-cpu:0.9.1-oe2403lts
+    image: openeuler/vllm-cpu:0.10.1-oe2403lts
     container_name: vllm-service
     ports:
       - "9009:80"
     volumes:
       - "${MODEL_CACHE:-./data}:/root/.cache/huggingface/hub"
     shm_size: 128g
-    privileged: true
     environment:
       no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}

--- a/CodeGen/docker_compose/intel/cpu/xeon/compose_openeuler.yaml
+++ b/CodeGen/docker_compose/intel/cpu/xeon/compose_openeuler.yaml
@@ -4,14 +4,13 @@
 services:
 
   vllm-service:
-    image: openeuler/vllm-cpu:0.9.1-oe2403lts
+    image: openeuler/vllm-cpu:0.10.1-oe2403lts
     container_name: vllm-server
     ports:
       - "8028:80"
     volumes:
       - "${MODEL_CACHE:-./data}:/root/.cache/huggingface/hub"
     shm_size: 1g
-    privileged: true
     environment:
       no_proxy: ${no_proxy}
       http_proxy: ${http_proxy}


### PR DESCRIPTION
## Description

This PR updates the `vllm-service` configuration in the Docker Compose files for the `AudioQnA`, `ChatQnA`, and `CodeGen` services. The main changes are upgrading the `vllm-cpu` image version and removing the unnecessary `privileged: true` flag from the service definitions.

**vllm-service configuration updates:**

* Upgraded the `vllm-service` Docker image from `openeuler/vllm-cpu:0.9.1-oe2403lts` to `openeuler/vllm-cpu:0.10.1-oe2403lts` in `AudioQnA`, `ChatQnA`, and `CodeGen` Compose files. [[1]](diffhunk://#diff-aee097a386cdc15bb4841ba8132893e016f9401de43b2cce41bc07a65af9a761L28-L35) [[2]](diffhunk://#diff-e433e1ddf46d184b769dbd1b667e380933766341e09d06a0d4ebe35364794ac3L91-L98) [[3]](diffhunk://#diff-0f41d99452a1be6ae3e6ae84f6f1f2efad9b876060cadf09c98548b3e6b1d1a6L7-L14)
* Removed the `privileged: true` flag from the `vllm-service` configuration in all three Compose files, improving security. [[1]](diffhunk://#diff-aee097a386cdc15bb4841ba8132893e016f9401de43b2cce41bc07a65af9a761L28-L35) [[2]](diffhunk://#diff-e433e1ddf46d184b769dbd1b667e380933766341e09d06a0d4ebe35364794ac3L91-L98) [[3]](diffhunk://#diff-0f41d99452a1be6ae3e6ae84f6f1f2efad9b876060cadf09c98548b3e6b1d1a6L7-L14)

## Issues

https://github.com/opea-project/GenAIExamples/issues/2207

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
