### PR TITLE
Porting DBQnA to Text2Query

### DIFF
--- a/DBQnA/docker_compose/amd/gpu/rocm/README.md
+++ b/DBQnA/docker_compose/amd/gpu/rocm/README.md
@@ -9,13 +9,17 @@ This document outlines the deployment process for DBQnA application which helps 
 
 This section describes how to quickly deploy and test the DBQnA service manually on AMD GPU (ROCm). The basic steps are:
 
-1. [Access the Code](#access-the-code)
-2. [Generate a HuggingFace Access Token](#generate-a-huggingface-access-token)
-3. [Configure the Deployment Environment](#configure-the-deployment-environment)
-4. [Deploy the Service Using Docker Compose](#deploy-the-service-using-docker-compose)
-5. [Check the Deployment Status](#check-the-deployment-status)
-6. [Test the Pipeline](#test-the-pipeline)
-7. [Cleanup the Deployment](#cleanup-the-deployment)
+- [Example DBQnA Deployment on AMD GPU (ROCm)](#example-dbqna-deployment-on-amd-gpu-rocm)
+  - [DBQnA Quick Start Deployment](#dbqna-quick-start-deployment)
+    - [Access the Code](#access-the-code)
+    - [Generate a HuggingFace Access Token](#generate-a-huggingface-access-token)
+    - [Configure the Deployment Environment](#configure-the-deployment-environment)
+    - [Deploy the Service Using Docker Compose](#deploy-the-service-using-docker-compose)
+    - [Check the Deployment Status](#check-the-deployment-status)
+    - [Test the Pipeline](#test-the-pipeline)
+    - [Cleanup the Deployment](#cleanup-the-deployment)
+  - [DBQnA Docker Compose Files](#dbqna-docker-compose-files)
+  - [DBQnA Service Configuration for AMD GPUs](#dbqna-service-configuration-for-amd-gpus)
 
 ### Access the Code
 
@@ -73,10 +77,11 @@ For the default deployment, the following 4 containers should be running.
 Once the DBQnA service are running, test the pipeline using the following command:
 
 ```bash
-curl http://${host_ip}:${DBQNA_TEXT_TO_SQL_PORT}/v1/texttosql \
+url="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${host_ip}:5442/${POSTGRES_DB}"
+curl --connect-timeout 5 --max-time 120000 http://${host_ip}:9090/v1/text2query\
     -X POST \
-    -d '{"input_text": "Find the total number of Albums.","conn_str": {"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${host_ip}'", "port": "5442", "database": "'${POSTGRES_DB}'"}}' \
-    -H 'Content-Type: application/json'
+    -d '{"query": "Find the total number of Albums.","conn_type": "sql", "conn_url": "'${url}'", "conn_user": "'${POSTGRES_USER}'","conn_password": "'${POSTGRES_PASSWORD}'","conn_dialect": "postgresql" }' \
+    -H 'Content-Type: application/json')
 ```
 
 ### Cleanup the Deployment
@@ -97,7 +102,7 @@ The compose.yaml is default compose file using tgi as serving framework
 | ----------------- | -------------------------------------------------------- |
 | dbqna-tgi-service | ghcr.io/huggingface/text-generation-inference:2.4.1-rocm |
 | postgres          | postgres:latest                                          |
-| text2sql          | opea/text2sql:latest                                     |
+| text2sql          | opea/text2query-sql:latest                               |
 | text2sql-react-ui | opea/text2sql-react-ui:latest                            |
 
 ## DBQnA Service Configuration for AMD GPUs
@@ -108,5 +113,5 @@ The table provides a comprehensive overview of the DBQnA service utilized across
 | ----------------- | -------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------- |
 | dbqna-tgi-service | ghcr.io/huggingface/text-generation-inference:2.4.1-rocm | No       | Specific to the TGI deployment, focuses on text generation inference using AMD GPU (ROCm) hardware. |
 | postgres          | postgres:latest                                          | No       | Provides the relational database backend for storing and querying data used by the DBQnA pipeline.  |
-| text2sql          | opea/text2sql:latest                                     | No       | Handles text-to-SQL conversion tasks.                                                               |
+| text2sql          | opea/text2query-sql:latest                               | No       | Handles text-to-SQL conversion tasks.                                                               |
 | text2sql-react-ui | opea/text2sql-react-ui:latest                            | No       | Provides the user interface for the DBQnA service.                                                  |

--- a/DBQnA/docker_compose/amd/gpu/rocm/compose.yaml
+++ b/DBQnA/docker_compose/amd/gpu/rocm/compose.yaml
@@ -47,12 +47,16 @@ services:
       - ./chinook.sql:/docker-entrypoint-initdb.d/chinook.sql
 
   text2sql:
-    image: opea/text2sql:latest
+    image: opea/text2query-sql:latest
     container_name: text2sql
     ports:
-      - "${DBQNA_TEXT_TO_SQL_PORT:-9090}:8080"
+      - "${DBQNA_TEXT_TO_SQL_PORT:-9090}:9097"
     environment:
       TGI_LLM_ENDPOINT: ${DBQNA_TGI_LLM_ENDPOINT}
+      TEXT2QUERY_COMPONENT_NAME: OPEA_TEXT2QUERY_SQL
+    depends_on:
+      - dbqna-tgi-service
+      - postgres
 
   text2sql-react-ui:
     image: opea/text2sql-react-ui:latest

--- a/DBQnA/docker_compose/intel/cpu/xeon/compose.yaml
+++ b/DBQnA/docker_compose/intel/cpu/xeon/compose.yaml
@@ -31,12 +31,16 @@ services:
       - ./chinook.sql:/docker-entrypoint-initdb.d/chinook.sql
 
   text2sql-service:
-    image: ${REGISTRY:-opea}/text2sql:${TAG:-latest}
+    image: ${REGISTRY:-opea}/text2query-sql:${TAG:-latest}
     container_name: text2sql-service
     ports:
-      - "${TEXT2SQL_PORT}:8080"
+      - "${TEXT2SQL_PORT}:9097"
     environment:
       - TGI_LLM_ENDPOINT=${TGI_LLM_ENDPOINT}
+      - TEXT2QUERY_COMPONENT_NAME=OPEA_TEXT2QUERY_SQL
+    depends_on:
+      - tgi-service
+      - postgres
 
   dbqna-xeon-react-ui-server:
     image: ${REGISTRY:-opea}/text2sql-react-ui:${TAG:-latest}

--- a/DBQnA/docker_image_build/build.yaml
+++ b/DBQnA/docker_image_build/build.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 services:
-  text2sql:
+  text2query-sql:
     build:
       context: GenAIComps
       dockerfile: comps/text2query/src/Dockerfile
@@ -19,5 +19,5 @@ services:
       dockerfile: ./docker/Dockerfile.react
       args:
         texttosql_url: ${build_texttosql_url}
-    extends: text2sql
+    extends: text2query-sql
     image: ${REGISTRY:-opea}/text2sql-react-ui:${TAG:-latest}

--- a/DBQnA/docker_image_build/build.yaml
+++ b/DBQnA/docker_image_build/build.yaml
@@ -5,14 +5,14 @@ services:
   text2sql:
     build:
       context: GenAIComps
-      dockerfile: comps/text2sql/src/Dockerfile
+      dockerfile: comps/text2query/src/Dockerfile
       args:
         IMAGE_REPO: ${REGISTRY:-opea}
         BASE_TAG: ${TAG:-latest}
         http_proxy: ${http_proxy}
         https_proxy: ${https_proxy}
         no_proxy: ${no_proxy}
-    image: ${REGISTRY:-opea}/text2sql:${TAG:-latest}
+    image: ${REGISTRY:-opea}/text2query-sql:${TAG:-latest}
   text2sql-react-ui:
     build:
       context: ../ui

--- a/DBQnA/tests/test_compose_on_rocm.sh
+++ b/DBQnA/tests/test_compose_on_rocm.sh
@@ -48,9 +48,10 @@ function start_services() {
 }
 
 function validate_microservice() {
-    result=$(http_proxy="" curl --connect-timeout 5 --max-time 120000 http://${ip_address}:${DBQNA_TEXT_TO_SQL_PORT}/v1/text2sql \
+    url="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${ip_address}:5442/${POSTGRES_DB}"
+    result=$(http_proxy="" curl --connect-timeout 5 --max-time 120000 http://${ip_address}:$TEXT2SQL_PORT/v1/text2query\
         -X POST \
-        -d '{"input_text": "Find the total number of Albums.","conn_str": {"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${ip_address}'", "port": "5442", "database": "'${POSTGRES_DB}'" }}' \
+        -d '{"query": "Find the total number of Albums.","conn_type": "sql", "conn_url": "'${url}'", "conn_user": "'${POSTGRES_USER}'","conn_password": "'${POSTGRES_PASSWORD}'","conn_dialect": "postgresql" }' \
         -H 'Content-Type: application/json')
 
     if echo "$result" | jq -e '.result.output' > /dev/null 2>&1; then

--- a/DBQnA/tests/test_compose_on_xeon.sh
+++ b/DBQnA/tests/test_compose_on_xeon.sh
@@ -48,9 +48,10 @@ function start_services() {
 }
 
 function validate_microservice() {
-    result=$(http_proxy="" curl --connect-timeout 5 --max-time 120000 http://${ip_address}:$TEXT2SQL_PORT/v1/text2sql\
+    url="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${ip_address}:5442/${POSTGRES_DB}"
+    result=$(http_proxy="" curl --connect-timeout 5 --max-time 120000 http://${ip_address}:$TEXT2SQL_PORT/v1/text2query\
         -X POST \
-        -d '{"input_text": "Find the total number of Albums.","conn_str": {"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${ip_address}'", "port": "5442", "database": "'${POSTGRES_DB}'" }}' \
+        -d '{"query": "Find the total number of Albums.","conn_type": "sql", "conn_url": "'${url}'", "conn_user": "'${POSTGRES_USER}'","conn_password": "'${POSTGRES_PASSWORD}'","conn_dialect": "postgresql" }' \
         -H 'Content-Type: application/json')
 
     if echo "$result" | jq -e '.result.output' > /dev/null 2>&1; then

--- a/DBQnA/ui/react/src/App.test.tsx
+++ b/DBQnA/ui/react/src/App.test.tsx
@@ -43,6 +43,6 @@ test('testing api with dynamic host', async () => {
   expect(result.hasOwnProperty('sql')).toBe(true);
   expect(result.hasOwnProperty('output')).toBe(true);
   expect(result.hasOwnProperty('input')).toBe(true);
-  expect(result.input.input_text).toBe(question);
+  expect(result.input.query).toBe(question);
 
 }, apiTimeOutInSeconds * 1000);

--- a/DBQnA/ui/react/src/App.test.tsx
+++ b/DBQnA/ui/react/src/App.test.tsx
@@ -21,21 +21,17 @@ const getHostIP = () => {
 test('testing api with dynamic host', async () => {
   // Get the dynamic host IP
   const host = await getHostIP();
-  const endpointUrl = `http://${host}:9090/v1/text2sql`;
-
-  const formData = {
-    user: 'postgres',
-    database: 'chinook',
-    host: host,
-    password: 'testpwd',
-    port: '5442',
-  };
-
+  const endpointUrl = `http://${host}:9090/v1/text2query`;
+  const connUrl = `postgresql://postgres:testpwd@${host}:5442/chinook`;
   const question = "Find the total number of invoices.";
 
   const payload = {
-    input_text: question,
-    conn_str: formData,
+    query: question,
+    conn_type: "sql",
+    conn_url: connUrl,
+    conn_user: "postgres",
+    conn_password: "testpwd",
+    conn_dialect: "postgresql",
   };
 
   const response = await axios.post(endpointUrl, payload);

--- a/DBQnA/ui/react/src/components/DbConnect/DBConnect.tsx
+++ b/DBQnA/ui/react/src/components/DbConnect/DBConnect.tsx
@@ -42,8 +42,15 @@ const DBConnect: React.FC = () => {
     e.preventDefault();
     try {
       let api_response: Record<string, any>;
-      let unifiedConnData = {"conn_str":formData};
-      api_response = await axios.post(`${TEXT_TO_SQL_URL}/postgres/health`, unifiedConnData);
+      let connUrl = `postgresql://${formData.user}:${formData.password}@${formData.host}:${formData.port}/${formData.database}`;
+      let unifiedConnData = {
+        conn_type: "sql",
+        conn_url: connUrl,
+        conn_user: formData.user,
+        conn_password: formData.password,
+        conn_dialect: "postgresql",
+      };
+      api_response = await axios.post(`${TEXT_TO_SQL_URL}/db/health`, unifiedConnData);
 
       setSqlStatus(null);
       setSqlError(null);
@@ -74,13 +81,18 @@ const DBConnect: React.FC = () => {
     e.preventDefault();
     setIsLoading(true);
     try {
+      const connUrl = `postgresql://${formData.user}:${formData.password}@${formData.host}:${formData.port}/${formData.database}`;
       const payload = {
-        input_text: question,
-        conn_str: formData,
+        query: question,
+        conn_type: "sql",
+        conn_url: connUrl,
+        conn_user: formData.user,
+        conn_password: formData.password,
+        conn_dialect: "postgresql",
       };
 
       let api_response: Record<string, any>;
-      api_response = await axios.post(`${TEXT_TO_SQL_URL}/text2sql`, payload);
+      api_response = await axios.post(`${TEXT_TO_SQL_URL}/text2query`, payload);
 
       setSqlQuery(api_response.data.result.sql); // Assuming the API returns an SQL query
       setQueryOutput(api_response.data.result.output);


### PR DESCRIPTION
## Description

The deprecated Text2SQL microservice is being replaced by Text2Query, and we are currently porting DBQnA to the new service.

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)
