### PR TITLE
Fix the base image of CodeGen UI

### DIFF
--- a/CodeGen/ui/docker/Dockerfile.openEuler
+++ b/CodeGen/ui/docker/Dockerfile.openEuler
@@ -1,11 +1,15 @@
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Huawei Technologies Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
 # Use node 20.11.1 as the base image
-FROM node:20.11.1
+FROM openeuler/node:20.11.1-oe2403lts
 
 # Update package manager and install Git
-RUN apt-get update -y && apt-get install -y git
+RUN yum update -y && \
+    yum install -y \
+        git && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 # Copy the front-end code repository
 COPY svelte /home/user/svelte


### PR DESCRIPTION
This pull request updates the `Dockerfile.openEuler` to use an openEuler-based Node.js image, updates the copyright information, and switches from `apt-get` to `yum` for package management. The most important changes are:

**Base Image and OS Compatibility:**
* Changed the base image from the official Node.js image (`node:20.11.1`) to the openEuler-specific Node.js image (`openeuler/node:20.11.1-oe2403lts`) for better compatibility with openEuler environments.

**Package Management:**
* Switched package manager commands from `apt-get` (Debian/Ubuntu) to `yum` (RPM/openEuler), including updating, installing `git`, cleaning up, and removing cache directories to align with openEuler best practices.

**Legal and Attribution:**
* Updated the copyright notice from Intel Corporation (2024) to Huawei Technologies Co., Ltd. (2025).