### PR TITLE
Potential fix for code scanning alert no. 27: Uncontrolled data used in path expression

### DIFF
--- a/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
+++ b/MultimodalQnA/ui/gradio/multimodalqna_ui_gradio.py
@@ -383,8 +383,17 @@ def ingest_with_caption(filepath, text_caption, audio_caption, request: gr.Reque
     is_audio_caption = audio_caption is not None
     if is_audio_caption:
         verified_audio_path = os.path.normpath(audio_caption)
+        if not verified_audio_path.startswith(static_dir):
+            print("Found malicious audio file path!")
+            yield (
+                gr.Textbox(
+                    visible=True,
+                    value="Your uploaded audio file's path is not allowed. Please upload a valid file.",
+                )
+            )
+            return
         caption_basename = "{}{}".format(os.path.splitext(basename)[0], os.path.splitext(verified_audio_path)[-1])
-        caption_file = audio_caption
+        caption_file = verified_audio_path
     else:
         caption_basename = "{}.txt".format(os.path.splitext(basename)[0])
         caption_file = os.path.join(static_dir, caption_basename)


### PR DESCRIPTION
Potential fix for [https://github.com/opea-project/GenAIExamples/security/code-scanning/27](https://github.com/opea-project/GenAIExamples/security/code-scanning/27)

To fix the issue, we need to validate the `audio_caption` path to ensure it is within a trusted directory. This can be achieved by:
1. Normalizing the path using `os.path.normpath`.
2. Verifying that the normalized path starts with a predefined safe root directory (e.g., `static_dir`).
3. Rejecting the file if the validation fails, with an appropriate error message.

This approach ensures that even if the user provides a malicious path (e.g., `../../../etc/passwd`), it will not be allowed to access files outside the trusted directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
