### PR TITLE
Potential fix for code scanning alert no. 427: Uncontrolled data used in path expression

### DIFF
--- a/EdgeCraftRAG/edgecraftrag/utils.py
+++ b/EdgeCraftRAG/edgecraftrag/utils.py
@@ -45,7 +45,14 @@ def get_prompt_template(model_path, prompt_content=None, template_path=None, ena
     if prompt_content is not None:
         template = prompt_content
     elif template_path is not None:
-        template = Path(template_path).read_text(encoding=None)
+        # Safely load the template only if it is inside /templates (or other safe root)
+        safe_root = "/templates"
+        normalized_path = os.path.normpath(os.path.join(safe_root, template_path))
+        if not normalized_path.startswith(safe_root):
+            raise ValueError("Template path is outside of the allowed directory.")
+        if not os.path.exists(normalized_path):
+            raise FileNotFoundError("Template file does not exist.")
+        template = Path(normalized_path).read_text(encoding=None)
     else:
         template = DEFAULT_TEMPLATE
     tokenizer = AutoTokenizer.from_pretrained(model_path)


### PR DESCRIPTION
Potential fix for [https://github.com/opea-project/GenAIExamples/security/code-scanning/427](https://github.com/opea-project/GenAIExamples/security/code-scanning/427)
https://github.com/opea-project/GenAIExamples/issues/2352
test pass https://github.com/opea-project/GenAIExamples/actions/runs/20253422487
**How to, in general terms, fix the problem:**
Paths provided by untrusted users must be checked before use. A common solution is to restrict file access to a known-safe directory. This is typically implemented by joining the user-supplied path to a safe root, normalizing the path, and ensuring the result still points inside the intended directory.

**Detailed description of the single best way to fix the problem without changing existing functionality:**
- In `get_prompt_template`, before using `Path(template_path).read_text`, validate or restrict `template_path`.
- Adopt the pattern used in `QnAGenerator.prompt_handler`: define a trusted root (e.g., `/templates`), join and normalize the path, and verify that the resulting path starts with the root.
- Only after such validation, read the file.
- This edit should appear in `EdgeCraftRAG/edgecraftrag/utils.py` in the `get_prompt_template` method, surrounding or replacing the existing read logic for `template_path`.

**What is needed:**
- Possibly an import of `os.path` if not present (already present).
- Insert safe path logic in `get_prompt_template`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
