### PR TITLE
Potential fix for code scanning alert no. 29: Uncontrolled data used in path expression

### DIFF
--- a/CodeGen/ui/gradio/codegen_ui_gradio.py
+++ b/CodeGen/ui/gradio/codegen_ui_gradio.py
@@ -165,7 +165,7 @@ def generate_code(query, index=None, use_agent=False):
 def ingest_file(file, index=None, chunk_size=100, chunk_overlap=150):
     headers = {}
     # Restrict file access to UPLOAD_ROOT directory
-    UPLOAD_ROOT = os.path.abspath('./')
+    UPLOAD_ROOT = os.path.abspath("./")
     normalized_path = os.path.normpath(os.path.join(UPLOAD_ROOT, file))
     # Ensure the constructed path is still within the upload root
     if not normalized_path.startswith(UPLOAD_ROOT):


### PR DESCRIPTION
Potential fix for [https://github.com/opea-project/GenAIExamples/security/code-scanning/29](https://github.com/opea-project/GenAIExamples/security/code-scanning/29)

To fix uncontrolled path usage, restrict file access to a predefined and safe upload directory. Normalize and validate the user-supplied path before using it, ensuring that it does not escape the intended directory via path traversal or absolute paths.

Specifically:
- Create a constant, e.g. `UPLOAD_ROOT`, set to a directory dedicated to file uploads (e.g., `"./uploads"`).
- When the code receives a file path/filename from the user, join it with the root directory and call `os.path.normpath` to normalize the path.
- After joining and normalizing, ensure that the normalized path starts with the absolute path of the allowed upload directory. If it does not, reject the request.
- Import any necessary modules, such as `os.path`.

All these changes must be done within the context of the provided file. The main change is in `ingest_file`, adding a check before `open(file, "rb")` and rewriting the use of the user input path.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
