### PR TITLE
Update BrowserUseAgent to browser-use 0.13.8

### DIFF
--- a/BrowserUseAgent/Dockerfile
+++ b/BrowserUseAgent/Dockerfile
@@ -15,7 +15,7 @@ RUN uv pip install --system --upgrade pip setuptools uv && \
     $uvpip pytest-playwright && \
     playwright install chromium --with-deps --no-shell && \
     $uvpip -r requirements.txt && \
-    $uvpip posthog==5.4.0
+    $uvpip posthog==7.7.0
 
 USER user
 ENTRYPOINT ["python", "browser_use_agent.py"]

--- a/BrowserUseAgent/browser_use_agent.py
+++ b/BrowserUseAgent/browser_use_agent.py
@@ -5,11 +5,11 @@
 import os
 
 from browser_use import Agent, BrowserProfile
+from browser_use.llm import ChatOpenAI
 from comps import opea_microservices, register_microservice
 from comps.cores.telemetry.opea_telemetry import opea_telemetry
 from fastapi import Request
-from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 
 LLM = None
 BROWSER_PROFILE = None
@@ -21,7 +21,7 @@ def initiate_llm_and_browser(llm_endpoint: str, model: str, secret_key: str = "s
     # Initialize global LLM and BrowserProfile if not already initialized
     global LLM, BROWSER_PROFILE
     if not LLM:
-        LLM = ChatOpenAI(base_url=f"{llm_endpoint}/v1", model=model, api_key=SecretStr(secret_key), temperature=0.1)
+        LLM = ChatOpenAI(base_url=f"{llm_endpoint}/v1", model=model, api_key=secret_key, temperature=0.1)
     if not BROWSER_PROFILE:
         BROWSER_PROFILE = BrowserProfile(
             headless=True,
@@ -68,7 +68,6 @@ async def run(request: Request):
         task=chat_request.task_prompt,
         llm=llm,
         use_vision=chat_request.use_vision,
-        enable_memory=False,
         browser_profile=browser_profile,
     )
     history = await agent.run(max_steps=chat_request.agent_max_steps)

--- a/BrowserUseAgent/requirements.txt
+++ b/BrowserUseAgent/requirements.txt
@@ -1,1 +1,1 @@
-browser-use==0.3.2
+browser-use==0.13.8


### PR DESCRIPTION
## Summary
- migrate BrowserUseAgent from browser-use 0.3.2 to 0.13.8
- use the native Browser Use ChatOpenAI adapter and remove the retired enable_memory option
- pin PostHog 7.7.0 for dependency compatibility while keeping the service API unchanged

## Verification
- fresh Python 3.11 install of BrowserUseAgent/requirements.txt plus posthog 7.7.0
- pip dependency check
- Python compilation
- Browser Use Agent construction with ChatOpenAI, headless=true, and chromium_sandbox=false
- git diff --check